### PR TITLE
Remove Expo asset images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Mobile App
+
+A React Native mobile application is located in the `mobile` directory. It was bootstrapped with [Expo](https://expo.dev/).
+
+```bash
+cd mobile
+npm install
+npm start
+```
+
+Running `npm start` launches the Expo development server and opens Expo Dev Tools in your browser.

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,0 +1,37 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
+node_modules/
+
+# Expo
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+
+# Native
+.kotlin/
+*.orig.*
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+
+# Metro
+.metro-health-check*
+
+# debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+*.pem
+
+# local env files
+.env*.local
+
+# typescript
+*.tsbuildinfo

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,0 +1,20 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Open up App.js to start working on your app!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,15 @@
+# Mobile App
+
+This directory contains the React Native mobile application built with [Expo](https://expo.dev/).
+
+## Getting Started
+
+Install dependencies and start the development server:
+
+```bash
+cd mobile
+npm install
+npm start
+```
+
+Running `npm start` opens Expo Dev Tools in your browser. From there you can run the app on an Android or iOS simulator, or on a physical device with the Expo Go app.

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,17 @@
+{
+  "expo": {
+    "name": "mobile",
+    "slug": "mobile",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "newArchEnabled": true,
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "edgeToEdgeEnabled": true
+    },
+    "web": {}
+  }
+}

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,8 @@
+import { registerRootComponent } from 'expo';
+
+import App from './App';
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "mobile",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~53.0.10",
+    "expo-status-bar": "~2.2.3",
+    "react": "19.0.0",
+    "react-native": "0.79.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  },
+  "private": true
+}


### PR DESCRIPTION
## Summary
- remove binary images from `mobile/assets`
- clean up `app.json` so it no longer references the removed icons

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ef10ea00832daba6dca57bb1a9c5