### PR TITLE
Add initial Jest setup

### DIFF
--- a/__tests__/setup.test.ts
+++ b/__tests__/setup.test.ts
@@ -1,0 +1,10 @@
+describe('Jest Setup', () => {
+  it('should be configured correctly', () => {
+    expect(true).toBe(true);
+  });
+
+  it('should support TypeScript', () => {
+    const add = (a: number, b: number): number => a + b;
+    expect(add(1, 2)).toBe(3);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  preset: 'jest-expo',
+  transformIgnorePatterns: [
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg)'
+  ],
+  testEnvironment: 'node',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  testMatch: ['**/__tests__/**/*.(ts|tsx|js)', '**/*.(test|spec).(ts|tsx|js)'],
+  collectCoverageFrom: [
+    'app/**/*.{ts,tsx}',
+    '!app/**/*.d.ts',
+    '!app/**/_layout.tsx',
+    '!**/node_modules/**',
+  ],
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-native/extend-expect';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
## Summary
- configure Jest for Expo/React Native with TypeScript
- add jest setup file for testing library
- add npm scripts for running tests
- add a sample test verifying the setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684388d6aa98832d92b7299404a5a495