### PR TITLE
Add job types and utility helpers

### DIFF
--- a/app/types/Job.ts
+++ b/app/types/Job.ts
@@ -1,0 +1,18 @@
+export interface Job {
+  id: string;
+  title: string;
+  company: string;
+  location: string;
+  salary?: string;
+  description: string;
+  requirements: string[];
+  postedDate: string;
+  applicationUrl: string;
+  logoUrl?: string;
+  isRemote: boolean;
+  employmentType: 'full-time' | 'part-time' | 'contract' | 'internship';
+  experienceLevel: 'entry' | 'mid' | 'senior' | 'lead';
+  // For future auto-apply features
+  platform?: 'greenhouse' | 'lever' | 'ashby' | 'linkedin' | 'indeed' | 'other';
+  canAutoApply?: boolean;
+}

--- a/app/utils/__tests__/jobUtils.test.ts
+++ b/app/utils/__tests__/jobUtils.test.ts
@@ -1,0 +1,51 @@
+import { createMockJob, isJobNew } from '../jobUtils';
+
+describe('jobUtils', () => {
+  describe('createMockJob', () => {
+    it('should create a valid mock job with default values', () => {
+      const mockJob = createMockJob();
+      
+      expect(mockJob).toHaveProperty('id');
+      expect(mockJob).toHaveProperty('title');
+      expect(mockJob).toHaveProperty('company');
+      expect(mockJob).toHaveProperty('location');
+      expect(mockJob).toHaveProperty('description');
+      expect(mockJob.requirements).toBeInstanceOf(Array);
+      expect(mockJob.isRemote).toBe(false);
+      expect(mockJob.employmentType).toBe('full-time');
+    });
+
+    it('should override default values with provided partial job data', () => {
+      const mockJob = createMockJob({
+        title: 'Senior React Native Developer',
+        company: 'Tech Corp',
+        isRemote: true
+      });
+      
+      expect(mockJob.title).toBe('Senior React Native Developer');
+      expect(mockJob.company).toBe('Tech Corp');
+      expect(mockJob.isRemote).toBe(true);
+    });
+  });
+
+  describe('isJobNew', () => {
+    it('should return true for jobs posted within 7 days', () => {
+      const recentJob = createMockJob({
+        postedDate: new Date().toISOString()
+      });
+      
+      expect(isJobNew(recentJob)).toBe(true);
+    });
+
+    it('should return false for jobs posted more than 7 days ago', () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 10);
+      
+      const oldJob = createMockJob({
+        postedDate: oldDate.toISOString()
+      });
+      
+      expect(isJobNew(oldJob)).toBe(false);
+    });
+  });
+});

--- a/app/utils/jobUtils.ts
+++ b/app/utils/jobUtils.ts
@@ -1,0 +1,27 @@
+import { Job } from '../types/Job';
+
+export function createMockJob(overrides?: Partial<Job>): Job {
+  return {
+    id: Math.random().toString(36).substring(7),
+    title: 'Software Developer',
+    company: 'Example Corp',
+    location: 'New York, NY',
+    description: 'We are looking for a talented developer...',
+    requirements: ['React Native', 'TypeScript', 'Jest'],
+    postedDate: new Date().toISOString(),
+    applicationUrl: 'https://example.com/apply',
+    isRemote: false,
+    employmentType: 'full-time',
+    experienceLevel: 'mid',
+    ...overrides,
+  };
+}
+
+export function isJobNew(job: Job, daysThreshold: number = 7): boolean {
+  const postedDate = new Date(job.postedDate);
+  const now = new Date();
+  const daysDifference =
+    (now.getTime() - postedDate.getTime()) / (1000 * 3600 * 24);
+
+  return daysDifference <= daysThreshold;
+}


### PR DESCRIPTION
## Summary
- define a Job interface
- add job utility helpers
- test job utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684395530588832da9ace8b427f93632