### PR TITLE
Add JobCard component with tests

### DIFF
--- a/app/components/JobCard.tsx
+++ b/app/components/JobCard.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Job } from '../types/Job';
+
+interface JobCardProps {
+  job: Job;
+}
+
+export const JobCard: React.FC<JobCardProps> = ({ job }) => {
+  const formatEmploymentType = (type: string): string => {
+    return type
+      .split('-')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>{job.title}</Text>
+        {job.isRemote && (
+          <View style={styles.remoteBadge}>
+            <Text style={styles.remoteBadgeText}>Remote</Text>
+          </View>
+        )}
+      </View>
+
+      <Text style={styles.company}>{job.company}</Text>
+      <Text style={styles.location}>{job.location}</Text>
+
+      {job.salary && <Text style={styles.salary}>{job.salary}</Text>}
+
+      <View style={styles.footer}>
+        <View style={styles.employmentBadge}>
+          <Text style={styles.employmentText}>
+            {formatEmploymentType(job.employmentType)}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'white',
+    borderRadius: 12,
+    padding: 20,
+    marginHorizontal: 20,
+    marginVertical: 10,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 10,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    flex: 1,
+    marginRight: 10,
+  },
+  company: {
+    fontSize: 16,
+    color: '#666',
+    marginBottom: 5,
+  },
+  location: {
+    fontSize: 14,
+    color: '#888',
+    marginBottom: 10,
+  },
+  salary: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2e7d32',
+    marginBottom: 15,
+  },
+  remoteBadge: {
+    backgroundColor: '#e3f2fd',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  remoteBadgeText: {
+    color: '#1976d2',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  footer: {
+    flexDirection: 'row',
+    marginTop: 10,
+  },
+  employmentBadge: {
+    backgroundColor: '#f5f5f5',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+  },
+  employmentText: {
+    fontSize: 12,
+    color: '#666',
+  },
+});

--- a/app/components/__tests__/JobCard.test.tsx
+++ b/app/components/__tests__/JobCard.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { JobCard } from '../JobCard';
+import { createMockJob } from '../../utils/jobUtils';
+
+describe('JobCard', () => {
+  it('should render job title', () => {
+    const job = createMockJob({ title: 'Senior React Developer' });
+    const { getByText } = render(<JobCard job={job} />);
+
+    expect(getByText('Senior React Developer')).toBeTruthy();
+  });
+
+  it('should render company name', () => {
+    const job = createMockJob({ company: 'Tech Innovators Inc' });
+    const { getByText } = render(<JobCard job={job} />);
+
+    expect(getByText('Tech Innovators Inc')).toBeTruthy();
+  });
+
+  it('should render location', () => {
+    const job = createMockJob({ location: 'San Francisco, CA' });
+    const { getByText } = render(<JobCard job={job} />);
+
+    expect(getByText('San Francisco, CA')).toBeTruthy();
+  });
+
+  it('should render salary when provided', () => {
+    const job = createMockJob({ salary: '$120k - $150k' });
+    const { getByText } = render(<JobCard job={job} />);
+
+    expect(getByText('$120k - $150k')).toBeTruthy();
+  });
+
+  it('should not crash when salary is not provided', () => {
+    const job = createMockJob({ salary: undefined });
+    const { queryByText } = render(<JobCard job={job} />);
+
+    expect(queryByText('$')).toBeNull();
+  });
+
+  it('should show remote badge when job is remote', () => {
+    const job = createMockJob({ isRemote: true });
+    const { getByText } = render(<JobCard job={job} />);
+
+    expect(getByText('Remote')).toBeTruthy();
+  });
+
+  it('should display employment type', () => {
+    const job = createMockJob({ employmentType: 'contract' });
+    const { getByText } = render(<JobCard job={job} />);
+
+    expect(getByText('Contract')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add JobCard unit tests following TDD
- implement JobCard component for displaying job info

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68439b2f63ac832d9d746e27b5d78aa2