### PR TITLE
Add SwipeableCard component and tests

### DIFF
--- a/app/components/SwipeableCard.tsx
+++ b/app/components/SwipeableCard.tsx
@@ -1,0 +1,95 @@
+import React, { useRef } from "react";
+import { Animated, Dimensions, StyleSheet } from "react-native";
+import PanResponder from "react-native/Libraries/Interaction/PanResponder";
+interface SwipeableCardProps {
+
+  children: React.ReactNode;
+  onSwipeLeft: () => void;
+  onSwipeRight: () => void;
+  swipeThreshold?: number;
+}
+
+const { width: screenWidth } = Dimensions.get('window');
+
+export const SwipeableCard: React.FC<SwipeableCardProps> = ({
+  children,
+  onSwipeLeft,
+  onSwipeRight,
+  swipeThreshold = 120,
+}) => {
+  const position = useRef(new Animated.ValueXY()).current;
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onPanResponderGrant: () => {
+        // Touch start handled here if needed
+      },
+      onPanResponderMove: (_evt, gestureState) => {
+        if (gestureState) {
+          position.setValue({ x: gestureState.dx, y: gestureState.dy });
+        }
+      },
+      onPanResponderRelease: (_evt, gestureState) => {
+        if (!gestureState) {
+          return;
+        }
+        if (gestureState.dx > swipeThreshold) {
+          // Swiped right
+          onSwipeRight();
+          Animated.spring(position, {
+            toValue: { x: screenWidth + 100, y: gestureState.dy },
+            useNativeDriver: false,
+          }).start(() => {
+            position.setValue({ x: 0, y: 0 });
+          });
+        } else if (gestureState.dx < -swipeThreshold) {
+          // Swiped left
+          onSwipeLeft();
+          Animated.spring(position, {
+            toValue: { x: -screenWidth - 100, y: gestureState.dy },
+            useNativeDriver: false,
+          }).start(() => {
+            position.setValue({ x: 0, y: 0 });
+          });
+        } else {
+          Animated.spring(position, {
+            toValue: { x: 0, y: 0 },
+            useNativeDriver: false,
+            friction: 4,
+          }).start();
+        }
+      },
+    })
+  ).current;
+
+  const getCardStyle = () => {
+    const rotate = position.x.interpolate({
+      inputRange: [-screenWidth / 2, 0, screenWidth / 2],
+      outputRange: ['-10deg', '0deg', '10deg'],
+      extrapolate: 'clamp',
+    });
+
+    return {
+      ...position.getLayout(),
+      transform: [{ rotate }],
+    };
+  };
+
+  return (
+    <Animated.View
+      style={[styles.container, getCardStyle()]}
+      {...panResponder.panHandlers}
+      testID="swipeable-card"
+    >
+      {children}
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    width: '100%',
+  },
+});

--- a/app/components/__tests__/SwipeableCard.test.tsx
+++ b/app/components/__tests__/SwipeableCard.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { View, Text } from 'react-native';
+import { SwipeableCard } from '../SwipeableCard';
+
+jest.mock('react-native/Libraries/Interaction/PanResponder', () => {
+  return {
+    create: (config: any) => ({
+      panHandlers: {
+        onStartShouldSetResponder: config.onStartShouldSetPanResponder,
+        onResponderGrant: (e: any) => config.onPanResponderGrant?.(e, e?.gestureState),
+        onResponderMove: (e: any) => config.onPanResponderMove?.(e, e?.gestureState),
+        onResponderRelease: (e: any) => config.onPanResponderRelease?.(e, e?.gestureState),
+      },
+    }),
+  };
+});
+
+jest.useFakeTimers();
+
+describe('SwipeableCard', () => {
+  const mockOnSwipeLeft = jest.fn();
+  const mockOnSwipeRight = jest.fn();
+  
+  const TestChild = () => (
+    <View testID="test-child">
+      <Text>Test Card Content</Text>
+    </View>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render children correctly', () => {
+    const { getByTestId } = render(
+      <SwipeableCard onSwipeLeft={mockOnSwipeLeft} onSwipeRight={mockOnSwipeRight}>
+        <TestChild />
+      </SwipeableCard>
+    );
+    
+    expect(getByTestId('test-child')).toBeTruthy();
+  });
+
+  it('should have swipeable-card testID', () => {
+    const { getByTestId } = render(
+      <SwipeableCard onSwipeLeft={mockOnSwipeLeft} onSwipeRight={mockOnSwipeRight}>
+        <TestChild />
+      </SwipeableCard>
+    );
+    
+    expect(getByTestId('swipeable-card')).toBeTruthy();
+  });
+
+  it('should handle pan responder grant', () => {
+    const { getByTestId } = render(
+      <SwipeableCard onSwipeLeft={mockOnSwipeLeft} onSwipeRight={mockOnSwipeRight}>
+        <TestChild />
+      </SwipeableCard>
+    );
+    
+    const card = getByTestId('swipeable-card');
+    
+    // Simulate touch start
+    fireEvent(card, 'responderGrant', {
+      nativeEvent: { locationX: 100, locationY: 100 }
+    });
+    
+    // Component should handle the event without crashing
+    expect(card).toBeTruthy();
+  });
+
+  it('should call onSwipeLeft when swiped left beyond threshold', () => {
+    const { getByTestId } = render(
+      <SwipeableCard 
+        onSwipeLeft={mockOnSwipeLeft} 
+        onSwipeRight={mockOnSwipeRight}
+        swipeThreshold={120}
+      >
+        <TestChild />
+      </SwipeableCard>
+    );
+    
+    const card = getByTestId('swipeable-card');
+    
+    // Simulate swipe left
+    fireEvent(card, 'responderGrant');
+    fireEvent(card, 'responderMove', {
+      nativeEvent: { pageX: 0, pageY: 100 }
+    });
+    fireEvent(card, 'responderRelease', {
+      nativeEvent: {},
+      gestureState: { dx: -150, dy: 0, vx: -0.5 }
+    });
+
+    jest.runAllTimers();
+    
+    expect(mockOnSwipeLeft).toHaveBeenCalledTimes(1);
+    expect(mockOnSwipeRight).not.toHaveBeenCalled();
+  });
+
+  it('should call onSwipeRight when swiped right beyond threshold', () => {
+    const { getByTestId } = render(
+      <SwipeableCard 
+        onSwipeLeft={mockOnSwipeLeft} 
+        onSwipeRight={mockOnSwipeRight}
+        swipeThreshold={120}
+      >
+        <TestChild />
+      </SwipeableCard>
+    );
+    
+    const card = getByTestId('swipeable-card');
+    
+    // Simulate swipe right
+    fireEvent(card, 'responderGrant');
+    fireEvent(card, 'responderMove', {
+      nativeEvent: { pageX: 200, pageY: 100 }
+    });
+    fireEvent(card, 'responderRelease', {
+      nativeEvent: {},
+      gestureState: { dx: 150, dy: 0, vx: 0.5 }
+    });
+
+    jest.runAllTimers();
+    
+    expect(mockOnSwipeRight).toHaveBeenCalledTimes(1);
+    expect(mockOnSwipeLeft).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- create SwipeableCard component to wrap content with swipe gestures
- write SwipeableCard unit tests with PanResponder mocked

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843a036dff4832dbe1c5cf2deabb08c