### PR TITLE
Add swipeable job card stack

### DIFF
--- a/app/components/JobCardStack.tsx
+++ b/app/components/JobCardStack.tsx
@@ -1,0 +1,126 @@
+import React, { useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Dimensions,
+} from 'react-native';
+import { Job } from '../types/Job';
+import { JobCard } from './JobCard';
+import { SwipeableCard } from './SwipeableCard';
+
+interface JobCardStackProps {
+  jobs: Job[];
+  onSwipeLeft: (job: Job) => void;
+  onSwipeRight: (job: Job) => void;
+  isLoading?: boolean;
+}
+
+const { height: screenHeight } = Dimensions.get('window');
+
+export const JobCardStack: React.FC<JobCardStackProps> = ({
+  jobs,
+  onSwipeLeft,
+  onSwipeRight,
+  isLoading = false,
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleSwipeLeft = useCallback(() => {
+    if (currentIndex < jobs.length) {
+      onSwipeLeft(jobs[currentIndex]);
+      setCurrentIndex(prev => prev + 1);
+    }
+  }, [currentIndex, jobs, onSwipeLeft]);
+
+  const handleSwipeRight = useCallback(() => {
+    if (currentIndex < jobs.length) {
+      onSwipeRight(jobs[currentIndex]);
+      setCurrentIndex(prev => prev + 1);
+    }
+  }, [currentIndex, jobs, onSwipeRight]);
+
+  if (isLoading) {
+    return (
+      <View style={styles.centerContainer}>
+        <ActivityIndicator
+          size="large"
+          color="#007AFF"
+          testID="loading-indicator"
+        />
+        <Text style={styles.loadingText}>Loading jobs...</Text>
+      </View>
+    );
+  }
+
+  if (jobs.length === 0 || currentIndex >= jobs.length) {
+    return (
+      <View style={styles.centerContainer}>
+        <Text style={styles.emptyText}>No more jobs available</Text>
+      </View>
+    );
+  }
+
+  // Render up to 3 cards for smooth transitions
+  const visibleCards = jobs
+    .slice(currentIndex, currentIndex + 3)
+    .map((job, index) => {
+      const isTopCard = index === 0;
+
+      return (
+        <View
+          key={job.id}
+          style={[
+            styles.cardContainer,
+            {
+              zIndex: 3 - index,
+              top: index * 8,
+              opacity: index === 2 ? 0.7 : 1,
+              transform: [{ scale: 1 - index * 0.03 }],
+            },
+          ]}
+          pointerEvents={isTopCard ? 'auto' : 'none'}
+        >
+          {isTopCard ? (
+            <SwipeableCard
+              onSwipeLeft={handleSwipeLeft}
+              onSwipeRight={handleSwipeRight}
+            >
+              <JobCard job={job} />
+            </SwipeableCard>
+          ) : (
+            <JobCard job={job} />
+          )}
+        </View>
+      );
+    });
+
+  return <View style={styles.container}>{visibleCards.reverse()}</View>;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginTop: 50,
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cardContainer: {
+    position: 'absolute',
+    width: '100%',
+  },
+  emptyText: {
+    fontSize: 18,
+    color: '#666',
+    textAlign: 'center',
+  },
+  loadingText: {
+    marginTop: 10,
+    fontSize: 16,
+    color: '#666',
+  },
+});

--- a/app/components/__tests__/JobCardStack.test.tsx
+++ b/app/components/__tests__/JobCardStack.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { JobCardStack } from '../JobCardStack';
+import { createMockJob } from '../../utils/jobUtils';
+import { Job } from '../../types/Job';
+
+// Mock the SwipeableCard component to simplify testing
+jest.mock('../SwipeableCard', () => ({
+  SwipeableCard: jest.fn(({ children }) => <>{children}</>),
+}));
+
+import { SwipeableCard } from '../SwipeableCard';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('JobCardStack', () => {
+  const createMockJobs = (count: number): Job[] => {
+    return Array.from({ length: count }, (_, i) =>
+      createMockJob({
+        id: `job-${i}`,
+        title: `Job Title ${i}`,
+        company: `Company ${i}`,
+      })
+    );
+  };
+
+  it('should render empty state when no jobs provided', () => {
+    const { getByText } = render(
+      <JobCardStack jobs={[]} onSwipeLeft={() => {}} onSwipeRight={() => {}} />
+    );
+
+    expect(getByText('No more jobs available')).toBeTruthy();
+  });
+
+  it('should render the first job card', () => {
+    const jobs = createMockJobs(3);
+    const { getByText } = render(
+      <JobCardStack jobs={jobs} onSwipeLeft={() => {}} onSwipeRight={() => {}} />
+    );
+
+    expect(getByText('Job Title 0')).toBeTruthy();
+    expect(getByText('Company 0')).toBeTruthy();
+  });
+
+  it('should call onSwipeLeft with job data', () => {
+    const mockOnSwipeLeft = jest.fn();
+    const jobs = createMockJobs(2);
+
+    render(
+      <JobCardStack jobs={jobs} onSwipeLeft={mockOnSwipeLeft} onSwipeRight={() => {}} />
+    );
+
+    // Since we mocked SwipeableCard, we need to test the callback directly
+    const { onSwipeLeft: propOnSwipeLeft } = (SwipeableCard as jest.Mock).mock.calls[0][0];
+    propOnSwipeLeft();
+
+    expect(mockOnSwipeLeft).toHaveBeenCalledWith(jobs[0]);
+  });
+
+  it('should show loading state when isLoading is true', () => {
+    const jobs = createMockJobs(2);
+    const { getByTestId } = render(
+      <JobCardStack
+        jobs={jobs}
+        onSwipeLeft={() => {}}
+        onSwipeRight={() => {}}
+        isLoading={true}
+      />
+    );
+
+    expect(getByTestId('loading-indicator')).toBeTruthy();
+  });
+
+  it('should render preview of next cards', () => {
+    const jobs = createMockJobs(4);
+    const { getByText, queryByText } = render(
+      <JobCardStack jobs={jobs} onSwipeLeft={() => {}} onSwipeRight={() => {}} />
+    );
+
+    // Should show current card
+    expect(getByText('Job Title 0')).toBeTruthy();
+
+    // Should not show cards beyond preview limit
+    expect(queryByText('Job Title 3')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `JobCardStack` for managing swipeable job cards
- mock `SwipeableCard` in new JobCardStack tests
- test card rendering, callbacks and loading state

## Testing
- `npx jest --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843c7e7db08832da4dd6de4aa39932d