### PR TITLE
Add JobService with full test coverage

### DIFF
--- a/app/services/__tests__/jobService.test.ts
+++ b/app/services/__tests__/jobService.test.ts
@@ -1,0 +1,103 @@
+import { JobService } from '../jobService';
+import { Job } from '../../types/Job';
+
+describe('JobService', () => {
+  let jobService: JobService;
+
+  beforeEach(() => {
+    jobService = new JobService();
+  });
+
+  describe('fetchJobs', () => {
+    it('should return an array of jobs', async () => {
+      const jobs = await jobService.fetchJobs();
+      
+      expect(Array.isArray(jobs)).toBe(true);
+      expect(jobs.length).toBeGreaterThan(0);
+    });
+
+    it('should return jobs with valid structure', async () => {
+      const jobs = await jobService.fetchJobs();
+      const firstJob = jobs[0];
+      
+      expect(firstJob).toHaveProperty('id');
+      expect(firstJob).toHaveProperty('title');
+      expect(firstJob).toHaveProperty('company');
+      expect(firstJob).toHaveProperty('location');
+      expect(firstJob).toHaveProperty('description');
+      expect(firstJob).toHaveProperty('requirements');
+      expect(firstJob).toHaveProperty('postedDate');
+      expect(firstJob).toHaveProperty('applicationUrl');
+    });
+
+    it('should return at least 10 mock jobs', async () => {
+      const jobs = await jobService.fetchJobs();
+      
+      expect(jobs.length).toBeGreaterThanOrEqual(10);
+    });
+  });
+
+  describe('filterJobsByLocation', () => {
+    it('should filter jobs by location keyword', async () => {
+      const allJobs = await jobService.fetchJobs();
+      const nycJobs = jobService.filterJobsByLocation(allJobs, 'New York');
+      
+      expect(nycJobs.length).toBeGreaterThan(0);
+      nycJobs.forEach(job => {
+        expect(job.location.toLowerCase()).toContain('new york');
+      });
+    });
+
+    it('should return empty array when no jobs match location', async () => {
+      const allJobs = await jobService.fetchJobs();
+      const marsJobs = jobService.filterJobsByLocation(allJobs, 'Mars');
+      
+      expect(marsJobs).toEqual([]);
+    });
+
+    it('should be case insensitive', async () => {
+      const allJobs = await jobService.fetchJobs();
+      const upperCaseResults = jobService.filterJobsByLocation(allJobs, 'REMOTE');
+      const lowerCaseResults = jobService.filterJobsByLocation(allJobs, 'remote');
+      
+      expect(upperCaseResults.length).toBe(lowerCaseResults.length);
+    });
+  });
+
+  describe('filterJobsByExperienceLevel', () => {
+    it('should filter jobs by experience level', async () => {
+      const allJobs = await jobService.fetchJobs();
+      const entryJobs = jobService.filterJobsByExperienceLevel(allJobs, 'entry');
+      
+      expect(entryJobs.length).toBeGreaterThan(0);
+      entryJobs.forEach(job => {
+        expect(job.experienceLevel).toBe('entry');
+      });
+    });
+
+    it('should handle multiple experience levels', async () => {
+      const allJobs = await jobService.fetchJobs();
+      const juniorJobs = jobService.filterJobsByExperienceLevel(allJobs, ['entry', 'mid']);
+      
+      juniorJobs.forEach(job => {
+        expect(['entry', 'mid']).toContain(job.experienceLevel);
+      });
+    });
+  });
+
+  describe('sortJobsByDate', () => {
+    it('should sort jobs from newest to oldest', () => {
+      const jobs: Job[] = [
+        { postedDate: '2024-01-01', id: '1' } as Job,
+        { postedDate: '2024-03-01', id: '2' } as Job,
+        { postedDate: '2024-02-01', id: '3' } as Job,
+      ];
+      
+      const sorted = jobService.sortJobsByDate(jobs);
+      
+      expect(sorted[0].id).toBe('2');
+      expect(sorted[1].id).toBe('3');
+      expect(sorted[2].id).toBe('1');
+    });
+  });
+});

--- a/app/services/jobService.ts
+++ b/app/services/jobService.ts
@@ -1,0 +1,145 @@
+import { Job } from '../types/Job';
+import { createMockJob } from '../utils/jobUtils';
+
+export class JobService {
+  // Mock data for now, will be replaced with API calls later
+  private mockJobs: Job[] = [
+    createMockJob({
+      id: '1',
+      title: 'Senior React Native Developer',
+      company: 'TechCorp',
+      location: 'New York, NY',
+      salary: '$150k - $180k',
+      isRemote: false,
+      experienceLevel: 'senior',
+      platform: 'greenhouse',
+      canAutoApply: true,
+    }),
+    createMockJob({
+      id: '2',
+      title: 'Mobile Engineer',
+      company: 'StartupXYZ',
+      location: 'Remote',
+      salary: '$120k - $140k',
+      isRemote: true,
+      experienceLevel: 'mid',
+      platform: 'lever',
+      canAutoApply: true,
+    }),
+    createMockJob({
+      id: '3',
+      title: 'Junior React Developer',
+      company: 'Digital Agency',
+      location: 'San Francisco, CA',
+      salary: '$80k - $100k',
+      experienceLevel: 'entry',
+      platform: 'ashby',
+      canAutoApply: true,
+    }),
+    createMockJob({
+      id: '4',
+      title: 'Full Stack Developer',
+      company: 'Enterprise Co',
+      location: 'Chicago, IL',
+      salary: '$110k - $130k',
+      experienceLevel: 'mid',
+      employmentType: 'full-time',
+    }),
+    createMockJob({
+      id: '5',
+      title: 'React Native Contractor',
+      company: 'Consulting Firm',
+      location: 'Remote',
+      isRemote: true,
+      experienceLevel: 'senior',
+      employmentType: 'contract',
+    }),
+    createMockJob({
+      id: '6',
+      title: 'Mobile Dev Intern',
+      company: 'Big Tech Co',
+      location: 'Seattle, WA',
+      salary: '$25/hour',
+      experienceLevel: 'entry',
+      employmentType: 'internship',
+    }),
+    createMockJob({
+      id: '7',
+      title: 'Lead Mobile Engineer',
+      company: 'FinTech Startup',
+      location: 'New York, NY',
+      salary: '$180k - $220k',
+      experienceLevel: 'lead',
+      platform: 'linkedin',
+    }),
+    createMockJob({
+      id: '8',
+      title: 'React Developer',
+      company: 'Healthcare Tech',
+      location: 'Boston, MA',
+      experienceLevel: 'mid',
+      platform: 'indeed',
+    }),
+    createMockJob({
+      id: '9',
+      title: 'Senior Frontend Engineer',
+      company: 'E-commerce Giant',
+      location: 'Remote',
+      isRemote: true,
+      salary: '$160k - $190k',
+      experienceLevel: 'senior',
+    }),
+    createMockJob({
+      id: '10',
+      title: 'React Native Developer',
+      company: 'Media Company',
+      location: 'Los Angeles, CA',
+      experienceLevel: 'mid',
+      employmentType: 'full-time',
+    }),
+  ];
+
+  async fetchJobs(): Promise<Job[]> {
+    // Simulate API delay
+    await new Promise(resolve => setTimeout(resolve, 500));
+    
+    // Return jobs with varied posted dates
+    const now = new Date();
+    return this.mockJobs.map((job, index) => {
+      const daysAgo = Math.floor(Math.random() * 30);
+      const postedDate = new Date(now);
+      postedDate.setDate(postedDate.getDate() - daysAgo);
+      
+      return {
+        ...job,
+        postedDate: postedDate.toISOString(),
+      };
+    });
+  }
+
+  filterJobsByLocation(jobs: Job[], location: string): Job[] {
+    const searchTerm = location.toLowerCase();
+    return jobs.filter(job => 
+      job.location.toLowerCase().includes(searchTerm)
+    );
+  }
+
+  filterJobsByExperienceLevel(
+    jobs: Job[], 
+    level: Job['experienceLevel'] | Job['experienceLevel'][]
+  ): Job[] {
+    const levels = Array.isArray(level) ? level : [level];
+    return jobs.filter(job => levels.includes(job.experienceLevel));
+  }
+
+  sortJobsByDate(jobs: Job[]): Job[] {
+    return [...jobs].sort((a, b) => {
+      const dateA = new Date(a.postedDate).getTime();
+      const dateB = new Date(b.postedDate).getTime();
+      return dateB - dateA; // Newest first
+    });
+  }
+}
+
+// Export singleton instance
+export const jobService = new JobService();


### PR DESCRIPTION
## Summary
- implement `JobService` for fetching and filtering mock jobs
- include job filtering utilities and sorting by date
- add comprehensive tests for `JobService`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843cf38c0b8832d9059aad49a0fb5eb