### PR TITLE
Add HomeScreen component with tests

### DIFF
--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,0 +1,149 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  TouchableOpacity,
+} from 'react-native';
+import { JobCardStack } from '../components/JobCardStack';
+import { Job } from '../types/Job';
+import { jobService } from '../services/jobService';
+
+export const HomeScreen: React.FC = () => {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [savedCount, setSavedCount] = useState(0);
+  const [rejectedCount, setRejectedCount] = useState(0);
+
+  const loadJobs = useCallback(async () => {
+    try {
+      const fetchedJobs = await jobService.fetchJobs();
+      const sortedJobs = jobService.sortJobsByDate(fetchedJobs);
+      setJobs(sortedJobs);
+    } catch (error) {
+      console.error('Failed to load jobs:', error);
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadJobs();
+  }, [loadJobs]);
+
+  const handleRefresh = useCallback(() => {
+    setIsRefreshing(true);
+    loadJobs();
+  }, [loadJobs]);
+
+  const handleSwipeLeft = useCallback((job: Job) => {
+    console.log('Rejected job:', job.title);
+    setRejectedCount(prev => prev + 1);
+  }, []);
+
+  const handleSwipeRight = useCallback((job: Job) => {
+    console.log('Saved job:', job.title);
+    setSavedCount(prev => prev + 1);
+  }, []);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Job Swiper</Text>
+        <TouchableOpacity
+          onPress={handleRefresh}
+          testID="refresh-button"
+          style={styles.refreshButton}
+        >
+          <Text style={styles.refreshButtonText}>↻</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.statsContainer}>
+        <View style={styles.statItem}>
+          <Text style={styles.statLabel}>Saved: {savedCount}</Text>
+        </View>
+        <View style={styles.statItem}>
+          <Text style={styles.statLabel}>Passed: {rejectedCount}</Text>
+        </View>
+      </View>
+
+      <View style={styles.instructions}>
+        <Text style={styles.instructionText}>← Swipe left to pass</Text>
+        <Text style={styles.instructionText}>Swipe right to save →</Text>
+      </View>
+
+      <View style={styles.cardContainer}>
+        <JobCardStack
+          jobs={jobs}
+          onSwipeLeft={handleSwipeLeft}
+          onSwipeRight={handleSwipeRight}
+          isLoading={isLoading || isRefreshing}
+        />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 15,
+    backgroundColor: 'white',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+    elevation: 4,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  refreshButton: {
+    padding: 10,
+  },
+  refreshButtonText: {
+    fontSize: 24,
+    color: '#007AFF',
+  },
+  statsContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    paddingVertical: 10,
+    backgroundColor: 'white',
+    marginTop: 1,
+  },
+  statItem: {
+    alignItems: 'center',
+  },
+  statLabel: {
+    fontSize: 16,
+    color: '#666',
+  },
+  instructions: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 30,
+    paddingVertical: 15,
+  },
+  instructionText: {
+    fontSize: 14,
+    color: '#888',
+    fontStyle: 'italic',
+  },
+  cardContainer: {
+    flex: 1,
+  },
+});

--- a/app/screens/__tests__/HomeScreen.test.tsx
+++ b/app/screens/__tests__/HomeScreen.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import { HomeScreen } from '../HomeScreen';
+import { jobService } from '../../services/jobService';
+
+// Mock the job service
+jest.mock('../../services/jobService');
+
+// Mock the components to simplify testing
+jest.mock('../../components/JobCardStack', () => ({
+  JobCardStack: ({ jobs, onSwipeLeft, onSwipeRight, isLoading }: any) => {
+    const MockComponent = require('react-native').View;
+    const MockText = require('react-native').Text;
+    
+    if (isLoading) {
+      return <MockText testID="loading">Loading...</MockText>;
+    }
+    
+    return (
+      <MockComponent testID="job-card-stack">
+        <MockText>{`Jobs count: ${jobs.length}`}</MockText>
+      </MockComponent>
+    );
+  },
+}));
+
+describe('HomeScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (jobService.sortJobsByDate as jest.Mock).mockImplementation((jobs: any) => jobs);
+  });
+
+  it('should render the screen with header', () => {
+    (jobService.fetchJobs as jest.Mock).mockResolvedValue([]);
+    
+    const { getByText } = render(<HomeScreen />);
+    
+    expect(getByText('Job Swiper')).toBeTruthy();
+  });
+
+  it('should show loading state initially', () => {
+    (jobService.fetchJobs as jest.Mock).mockImplementation(
+      () => new Promise(() => {}) // Never resolves
+    );
+    
+    const { getByTestId } = render(<HomeScreen />);
+    
+    expect(getByTestId('loading')).toBeTruthy();
+  });
+
+  it('should load and display jobs', async () => {
+    const mockJobs = [
+      { id: '1', title: 'Job 1' },
+      { id: '2', title: 'Job 2' },
+    ];
+    
+    (jobService.fetchJobs as jest.Mock).mockResolvedValue(mockJobs);
+    
+    const { getByText, getByTestId } = render(<HomeScreen />);
+    
+    await waitFor(() => {
+      expect(getByTestId('job-card-stack')).toBeTruthy();
+      expect(getByText('Jobs count: 2')).toBeTruthy();
+    });
+  });
+
+  it('should show swipe instructions', () => {
+    (jobService.fetchJobs as jest.Mock).mockResolvedValue([]);
+    
+    const { getByText } = render(<HomeScreen />);
+    
+    expect(getByText(/Swipe right to save/i)).toBeTruthy();
+    expect(getByText(/Swipe left to pass/i)).toBeTruthy();
+  });
+
+  it('should have refresh button', () => {
+    (jobService.fetchJobs as jest.Mock).mockResolvedValue([]);
+    
+    const { getByTestId } = render(<HomeScreen />);
+    
+    expect(getByTestId('refresh-button')).toBeTruthy();
+  });
+
+  it('should refresh jobs when refresh button is pressed', async () => {
+    const mockJobs = [{ id: '1', title: 'Job 1' }];
+    (jobService.fetchJobs as jest.Mock).mockResolvedValue(mockJobs);
+    
+    const { getByTestId } = render(<HomeScreen />);
+    
+    // Wait for initial load
+    await waitFor(() => {
+      expect(jobService.fetchJobs).toHaveBeenCalledTimes(1);
+    });
+    
+    // Press refresh
+    const refreshButton = getByTestId('refresh-button');
+    fireEvent.press(refreshButton);
+    
+    await waitFor(() => {
+      expect(jobService.fetchJobs).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should track saved and rejected jobs count', () => {
+    (jobService.fetchJobs as jest.Mock).mockResolvedValue([]);
+    
+    const { getByText } = render(<HomeScreen />);
+    
+    expect(getByText(/Saved: 0/)).toBeTruthy();
+    expect(getByText(/Passed: 0/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `HomeScreen` screen to manage job browsing
- add unit tests verifying HomeScreen behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843d278a75c832d92e75dd76291d692