### PR TITLE
Implement ApplicationsScreen component

### DIFF
--- a/app/screens/ApplicationsScreen.tsx
+++ b/app/screens/ApplicationsScreen.tsx
@@ -1,0 +1,332 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  RefreshControl,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { applicationService } from '../services/applicationService';
+import { Application, ApplicationStatus } from '../types/Application';
+
+type FilterType = 'all' | ApplicationStatus;
+
+export const ApplicationsScreen = () => {
+  const navigation = useNavigation();
+  const [applications, setApplications] = useState<Application[]>([]);
+  const [stats, setStats] = useState({
+    total: 0,
+    completed: 0,
+    pending: 0,
+    needsAttention: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [filter, setFilter] = useState<FilterType>('all');
+
+  const loadData = useCallback(async () => {
+    try {
+      const [apps, appStats] = await Promise.all([
+        applicationService.getApplications(),
+        applicationService.getApplicationStats(),
+      ]);
+      setApplications(apps);
+      setStats(appStats);
+    } catch (error) {
+      console.error('Error loading applications:', error);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleRefresh = () => {
+    setRefreshing(true);
+    loadData();
+  };
+
+  const handleStatusUpdate = async (applicationId: string, currentStatus: ApplicationStatus) => {
+    const nextStatus: ApplicationStatus = 
+      currentStatus === 'pending' ? 'completed' : 
+      currentStatus === 'needs_attention' ? 'pending' : 
+      'completed';
+    
+    try {
+      await applicationService.updateApplicationStatus(applicationId, nextStatus);
+      await loadData();
+    } catch (error) {
+      console.error('Error updating status:', error);
+    }
+  };
+
+  const getStatusColor = (status: ApplicationStatus) => {
+    switch (status) {
+      case 'completed':
+        return '#4CAF50';
+      case 'pending':
+        return '#FF9800';
+      case 'needs_attention':
+        return '#F44336';
+      default:
+        return '#757575';
+    }
+  };
+
+  const filteredApplications = applications.filter(app => 
+    filter === 'all' || app.status === filter
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.centerContainer}>
+        <ActivityIndicator size="large" testID="loading-indicator" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      style={styles.container}
+      testID="applications-scroll-view"
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={handleRefresh} />
+      }
+    >
+      {/* Statistics */}
+      <View style={styles.statsContainer}>
+        <View style={styles.statItem}>
+          <Text style={styles.statNumber}>{stats.total}</Text>
+          <Text style={styles.statLabel}>Total Applications</Text>
+        </View>
+        <View style={styles.statItem}>
+          <Text style={[styles.statNumber, { color: '#4CAF50' }]}>{stats.completed}</Text>
+          <Text style={styles.statLabel}>Completed</Text>
+        </View>
+        <View style={styles.statItem}>
+          <Text style={[styles.statNumber, { color: '#FF9800' }]}>{stats.pending}</Text>
+          <Text style={styles.statLabel}>Pending</Text>
+        </View>
+        <View style={styles.statItem}>
+          <Text style={[styles.statNumber, { color: '#F44336' }]}>{stats.needsAttention}</Text>
+          <Text style={styles.statLabel}>Needs Attention</Text>
+        </View>
+      </View>
+
+      {/* Filters */}
+      <ScrollView 
+        horizontal 
+        showsHorizontalScrollIndicator={false}
+        style={styles.filterContainer}
+      >
+        <TouchableOpacity
+          style={[styles.filterButton, filter === 'all' && styles.filterButtonActive]}
+          onPress={() => setFilter('all')}
+        >
+          <Text style={[styles.filterText, filter === 'all' && styles.filterTextActive]}>
+            All
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.filterButton, filter === 'needs_attention' && styles.filterButtonActive]}
+          onPress={() => setFilter('needs_attention')}
+        >
+          <Text style={[styles.filterText, filter === 'needs_attention' && styles.filterTextActive]}>
+            Needs Attention
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.filterButton, filter === 'pending' && styles.filterButtonActive]}
+          onPress={() => setFilter('pending')}
+        >
+          <Text style={[styles.filterText, filter === 'pending' && styles.filterTextActive]}>
+            Pending
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.filterButton, filter === 'completed' && styles.filterButtonActive]}
+          onPress={() => setFilter('completed')}
+        >
+          <Text style={[styles.filterText, filter === 'completed' && styles.filterTextActive]}>
+            Completed
+          </Text>
+        </TouchableOpacity>
+      </ScrollView>
+
+      {/* Applications List */}
+      {filteredApplications.length === 0 ? (
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>No applications yet</Text>
+          <Text style={styles.emptySubtitle}>
+            Start swiping on jobs to track your applications!
+          </Text>
+        </View>
+      ) : (
+        filteredApplications.map((application) => (
+          <TouchableOpacity
+            key={application.id}
+            style={styles.applicationCard}
+            testID={`application-${application.id}`}
+            onPress={() => navigation.navigate('JobDetails' as never, { job: application.job } as never)}
+          >
+            <View style={styles.applicationHeader}>
+              <View style={styles.applicationInfo}>
+                <Text style={styles.jobTitle}>{application.job.title}</Text>
+                <Text style={styles.company}>{application.job.company}</Text>
+                <Text style={styles.location}>{application.job.location}</Text>
+                <Text style={styles.appliedDate}>
+                  Applied: {new Date(application.appliedAt).toLocaleDateString()}
+                </Text>
+              </View>
+              <TouchableOpacity
+                style={[styles.statusBadge, { backgroundColor: getStatusColor(application.status) }]}
+                testID={`status-button-${application.id}`}
+                onPress={() => handleStatusUpdate(application.id, application.status)}
+              >
+                <Text style={styles.statusText}>
+                  {application.status.replace('_', ' ').toUpperCase()}
+                </Text>
+              </TouchableOpacity>
+            </View>
+            {application.notes && (
+              <Text style={styles.notes}>{application.notes}</Text>
+            )}
+          </TouchableOpacity>
+        ))
+      )}
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  centerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  statsContainer: {
+    flexDirection: 'row',
+    backgroundColor: 'white',
+    padding: 16,
+    marginBottom: 8,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  statNumber: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: '#333',
+  },
+  statLabel: {
+    fontSize: 12,
+    color: '#666',
+    marginTop: 4,
+  },
+  filterContainer: {
+    backgroundColor: 'white',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    marginBottom: 8,
+  },
+  filterButton: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: '#f0f0f0',
+    marginRight: 8,
+  },
+  filterButtonActive: {
+    backgroundColor: '#007bff',
+  },
+  filterText: {
+    color: '#666',
+    fontSize: 14,
+  },
+  filterTextActive: {
+    color: 'white',
+  },
+  applicationCard: {
+    backgroundColor: 'white',
+    marginHorizontal: 16,
+    marginBottom: 8,
+    padding: 16,
+    borderRadius: 8,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  applicationHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  applicationInfo: {
+    flex: 1,
+  },
+  jobTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 4,
+  },
+  company: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 2,
+  },
+  location: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 2,
+  },
+  appliedDate: {
+    fontSize: 12,
+    color: '#999',
+    marginTop: 4,
+  },
+  statusBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    alignSelf: 'flex-start',
+  },
+  statusText: {
+    color: 'white',
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  notes: {
+    fontSize: 14,
+    color: '#666',
+    marginTop: 8,
+    fontStyle: 'italic',
+  },
+  emptyState: {
+    padding: 32,
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 8,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: '#666',
+    textAlign: 'center',
+  },
+});

--- a/app/types/Application.ts
+++ b/app/types/Application.ts
@@ -1,9 +1,11 @@
 import { Job } from './Job';
 
+export type ApplicationStatus = 'pending' | 'completed' | 'needs_attention';
+
 export interface Application {
   id: string;
   job: Job;
-  status: 'pending' | 'completed' | 'needs_attention';
+  status: ApplicationStatus;
   appliedAt: Date;
   notes?: string;
   resumeVersion?: string;


### PR DESCRIPTION
## Summary
- add ApplicationsScreen component for listing and managing applications
- support application status type via ApplicationStatus

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6844a9dfd47c832da95a509832d1205b