### PR TITLE
Add ProfileScreen component with tests

### DIFF
--- a/app/screens/ProfileScreen.tsx
+++ b/app/screens/ProfileScreen.tsx
@@ -1,0 +1,323 @@
+import React, { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+import { applicationService } from '../services/applicationService';
+
+interface UserProfile {
+  name: string;
+  email: string;
+  phone: string;
+  location: string;
+  bio: string;
+  skills: string[];
+  experience: string;
+  education: string;
+}
+
+export const ProfileScreen = () => {
+  const navigation = useNavigation();
+  const [profile, setProfile] = useState<UserProfile>({
+    name: '',
+    email: '',
+    phone: '',
+    location: '',
+    bio: '',
+    skills: [],
+    experience: '',
+    education: '',
+  });
+  const [skillsText, setSkillsText] = useState('');
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  useEffect(() => {
+    loadProfile();
+  }, []);
+
+  const loadProfile = async () => {
+    try {
+      const savedProfile = await AsyncStorage.getItem('userProfile');
+      if (savedProfile) {
+        const parsed = JSON.parse(savedProfile);
+        setProfile(parsed);
+        setSkillsText(parsed.skills.join(', '));
+      }
+    } catch (error) {
+      console.error('Error loading profile:', error);
+    }
+  };
+
+  const saveProfile = async () => {
+    try {
+      const profileToSave = {
+        ...profile,
+        skills: skillsText
+          .split(',')
+          .map(skill => skill.trim())
+          .filter(skill => skill.length > 0),
+      };
+
+      await AsyncStorage.setItem('userProfile', JSON.stringify(profileToSave));
+      setShowSuccess(true);
+      setTimeout(() => setShowSuccess(false), 3000);
+    } catch (error) {
+      console.error('Error saving profile:', error);
+      Alert.alert('Error', 'Failed to save profile');
+    }
+  };
+
+  const clearAllData = () => {
+    Alert.alert(
+      'Clear All Data',
+      'This will delete all your profile information and job applications. Are you sure?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Clear',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await AsyncStorage.removeItem('userProfile');
+              await AsyncStorage.removeItem('applications');
+              await applicationService.clearAllApplications();
+
+              setProfile({
+                name: '',
+                email: '',
+                phone: '',
+                location: '',
+                bio: '',
+                skills: [],
+                experience: '',
+                education: '',
+              });
+              setSkillsText('');
+
+              Alert.alert('Success', 'All data has been cleared');
+            } catch (error) {
+              console.error('Error clearing data:', error);
+              Alert.alert('Error', 'Failed to clear data');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
+        {showSuccess && (
+          <View style={styles.successBanner}>
+            <Text style={styles.successText}>Profile saved successfully!</Text>
+          </View>
+        )}
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Basic Information</Text>
+
+          <Text style={styles.label}>Full Name</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="Your full name"
+            value={profile.name}
+            onChangeText={(text) => setProfile({ ...profile, name: text })}
+          />
+
+          <Text style={styles.label}>Email</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="your.email@example.com"
+            value={profile.email}
+            onChangeText={(text) => setProfile({ ...profile, email: text })}
+            keyboardType="email-address"
+            autoCapitalize="none"
+          />
+
+          <Text style={styles.label}>Phone</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="(555) 123-4567"
+            value={profile.phone}
+            onChangeText={(text) => setProfile({ ...profile, phone: text })}
+            keyboardType="phone-pad"
+          />
+
+          <Text style={styles.label}>Location</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="City, State"
+            value={profile.location}
+            onChangeText={(text) => setProfile({ ...profile, location: text })}
+          />
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Professional Information</Text>
+
+          <Text style={styles.label}>Bio</Text>
+          <TextInput
+            style={[styles.input, styles.textArea]}
+            placeholder="Tell us about yourself..."
+            value={profile.bio}
+            onChangeText={(text) => setProfile({ ...profile, bio: text })}
+            multiline
+            numberOfLines={4}
+          />
+
+          <Text style={styles.label}>Skills</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., JavaScript, React, Node.js"
+            value={skillsText}
+            onChangeText={setSkillsText}
+          />
+          <Text style={styles.hint}>Separate skills with commas</Text>
+
+          <Text style={styles.label}>Experience</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., 5 years"
+            value={profile.experience}
+            onChangeText={(text) => setProfile({ ...profile, experience: text })}
+          />
+
+          <Text style={styles.label}>Education</Text>
+          <TextInput
+            style={styles.input}
+            placeholder="e.g., BS Computer Science"
+            value={profile.education}
+            onChangeText={(text) => setProfile({ ...profile, education: text })}
+          />
+        </View>
+
+        <TouchableOpacity style={styles.saveButton} onPress={saveProfile}>
+          <Text style={styles.saveButtonText}>Save Profile</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.exportButton}
+          onPress={() => navigation.navigate('ExportResume' as never)}
+        >
+          <Text style={styles.exportButtonText}>Export Resume</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.clearButton} onPress={clearAllData}>
+          <Text style={styles.clearButtonText}>Clear All Data</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  scrollView: {
+    flex: 1,
+    padding: 16,
+  },
+  successBanner: {
+    backgroundColor: '#4CAF50',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  successText: {
+    color: 'white',
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+  section: {
+    backgroundColor: 'white',
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 16,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: '#333',
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 4,
+    marginTop: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    color: '#333',
+  },
+  textArea: {
+    minHeight: 100,
+    textAlignVertical: 'top',
+  },
+  hint: {
+    fontSize: 12,
+    color: '#999',
+    marginTop: 4,
+  },
+  saveButton: {
+    backgroundColor: '#007bff',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  saveButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  exportButton: {
+    backgroundColor: '#28a745',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  exportButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  clearButton: {
+    backgroundColor: '#dc3545',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 12,
+    marginBottom: 32,
+  },
+  clearButtonText: {
+    color: 'white',
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+});

--- a/app/screens/__tests__/ProfileScreen.test.tsx
+++ b/app/screens/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Alert } from 'react-native';
+import { act } from 'react-test-renderer';
+import { ProfileScreen } from '../ProfileScreen';
+import { applicationService } from '../../services/applicationService';
+
+// Mock AsyncStorage
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+// Mock navigation
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+  }),
+}));
+
+// Mock application service
+jest.mock('../../services/applicationService');
+
+describe('ProfileScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  const mockUserProfile = {
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '123-456-7890',
+    location: 'New York, NY',
+    bio: 'Experienced developer',
+    skills: ['React', 'TypeScript', 'Node.js'],
+    experience: '5 years',
+    education: 'BS Computer Science',
+  };
+
+  it('should render profile form with empty fields initially', () => {
+    const { getByPlaceholderText } = render(<ProfileScreen />);
+    
+    expect(getByPlaceholderText('Your full name')).toBeTruthy();
+    expect(getByPlaceholderText('your.email@example.com')).toBeTruthy();
+    expect(getByPlaceholderText('(555) 123-4567')).toBeTruthy();
+    expect(getByPlaceholderText('City, State')).toBeTruthy();
+    expect(getByPlaceholderText('Tell us about yourself...')).toBeTruthy();
+    expect(getByPlaceholderText('e.g., JavaScript, React, Node.js')).toBeTruthy();
+    expect(getByPlaceholderText('e.g., 5 years')).toBeTruthy();
+    expect(getByPlaceholderText('e.g., BS Computer Science')).toBeTruthy();
+  });
+
+  it('should load saved profile data', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(mockUserProfile));
+    
+    const { getByDisplayValue } = render(<ProfileScreen />);
+    
+    await waitFor(() => {
+      expect(getByDisplayValue('John Doe')).toBeTruthy();
+      expect(getByDisplayValue('john@example.com')).toBeTruthy();
+      expect(getByDisplayValue('123-456-7890')).toBeTruthy();
+      expect(getByDisplayValue('New York, NY')).toBeTruthy();
+      expect(getByDisplayValue('Experienced developer')).toBeTruthy();
+      expect(getByDisplayValue('React, TypeScript, Node.js')).toBeTruthy();
+      expect(getByDisplayValue('5 years')).toBeTruthy();
+      expect(getByDisplayValue('BS Computer Science')).toBeTruthy();
+    });
+  });
+
+  it('should update form fields when user types', () => {
+    const { getByPlaceholderText } = render(<ProfileScreen />);
+    
+    const nameInput = getByPlaceholderText('Your full name');
+    fireEvent.changeText(nameInput, 'Jane Smith');
+    
+    expect(nameInput.props.value).toBe('Jane Smith');
+  });
+
+  it('should save profile when save button is pressed', async () => {
+    const { getByPlaceholderText, getByText } = render(<ProfileScreen />);
+    
+    // Fill in the form
+    fireEvent.changeText(getByPlaceholderText('Your full name'), 'Jane Smith');
+    fireEvent.changeText(getByPlaceholderText('your.email@example.com'), 'jane@example.com');
+    fireEvent.changeText(getByPlaceholderText('(555) 123-4567'), '987-654-3210');
+    fireEvent.changeText(getByPlaceholderText('City, State'), 'Los Angeles, CA');
+    fireEvent.changeText(getByPlaceholderText('Tell us about yourself...'), 'Senior developer');
+    fireEvent.changeText(getByPlaceholderText('e.g., JavaScript, React, Node.js'), 'React, Vue');
+    fireEvent.changeText(getByPlaceholderText('e.g., 5 years'), '8 years');
+    fireEvent.changeText(getByPlaceholderText('e.g., BS Computer Science'), 'MS Computer Science');
+    
+    // Press save button
+    fireEvent.press(getByText('Save Profile'));
+    
+    await waitFor(() => {
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+        'userProfile',
+        JSON.stringify({
+          name: 'Jane Smith',
+          email: 'jane@example.com',
+          phone: '987-654-3210',
+          location: 'Los Angeles, CA',
+          bio: 'Senior developer',
+          skills: ['React', 'Vue'],
+          experience: '8 years',
+          education: 'MS Computer Science',
+        })
+      );
+    });
+  });
+
+  it('should show success message after saving', async () => {
+    const { getByPlaceholderText, getByText } = render(<ProfileScreen />);
+    
+    fireEvent.changeText(getByPlaceholderText('Your full name'), 'Test User');
+    fireEvent.press(getByText('Save Profile'));
+    
+    await waitFor(() => {
+      expect(getByText('Profile saved successfully!')).toBeTruthy();
+    });
+  });
+
+  it('should navigate to export resume screen', () => {
+    const { getByText } = render(<ProfileScreen />);
+    
+    fireEvent.press(getByText('Export Resume'));
+    
+    expect(mockNavigate).toHaveBeenCalledWith('ExportResume');
+  });
+
+  it('should clear all data when reset button is pressed', async () => {
+    (applicationService.clearAllApplications as jest.Mock).mockResolvedValue(undefined);
+    const alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation((title, message, buttons) => {
+        const confirmButton = buttons && (buttons as any)[1];
+        confirmButton?.onPress?.();
+      });
+
+    const { getByText } = render(<ProfileScreen />);
+
+    fireEvent.press(getByText('Clear All Data'));
+
+    await waitFor(() => {
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('userProfile');
+      expect(AsyncStorage.removeItem).toHaveBeenCalledWith('applications');
+      expect(applicationService.clearAllApplications).toHaveBeenCalled();
+    });
+
+    alertSpy.mockRestore();
+  });
+
+  it('should parse skills as comma-separated values', async () => {
+    const { getByPlaceholderText, getByText } = render(<ProfileScreen />);
+    
+    fireEvent.changeText(
+      getByPlaceholderText('e.g., JavaScript, React, Node.js'), 
+      'Python, Django, PostgreSQL, Docker'
+    );
+    fireEvent.press(getByText('Save Profile'));
+    
+    await waitFor(() => {
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1]
+      );
+      expect(savedData.skills).toEqual(['Python', 'Django', 'PostgreSQL', 'Docker']);
+    });
+  });
+
+  it('should handle empty skills gracefully', async () => {
+    const { getByPlaceholderText, getByText } = render(<ProfileScreen />);
+    
+    fireEvent.changeText(getByPlaceholderText('Your full name'), 'Test User');
+    fireEvent.changeText(getByPlaceholderText('e.g., JavaScript, React, Node.js'), '');
+    fireEvent.press(getByText('Save Profile'));
+    
+    await waitFor(() => {
+      const savedData = JSON.parse(
+        (AsyncStorage.setItem as jest.Mock).mock.calls[0][1]
+      );
+      expect(savedData.skills).toEqual([]);
+    });
+  });
+});

--- a/app/services/applicationService.ts
+++ b/app/services/applicationService.ts
@@ -86,6 +86,14 @@ export class ApplicationService {
       return [];
     }
   }
+
+  async clearAllApplications(): Promise<void> {
+    try {
+      await AsyncStorage.removeItem(APPLICATIONS_KEY);
+    } catch (error) {
+      console.error('Error clearing applications:', error);
+    }
+  }
 }
 
 export const applicationService = new ApplicationService();


### PR DESCRIPTION
## Summary
- implement `ProfileScreen` for managing user profile data
- add ability to clear all applications via `ApplicationService`
- provide a comprehensive test suite for the new screen

## Testing
- `npm test ProfileScreen`

------
https://chatgpt.com/codex/tasks/task_e_6844b0a2796c832db54301528c6f1b7e