### PR TITLE
Use Date type for Job postedDate

### DIFF
--- a/app/services/__tests__/jobService.test.ts
+++ b/app/services/__tests__/jobService.test.ts
@@ -88,9 +88,9 @@ describe('JobService', () => {
   describe('sortJobsByDate', () => {
     it('should sort jobs from newest to oldest', () => {
       const jobs: Job[] = [
-        { postedDate: '2024-01-01', id: '1' } as Job,
-        { postedDate: '2024-03-01', id: '2' } as Job,
-        { postedDate: '2024-02-01', id: '3' } as Job,
+        { postedDate: new Date('2024-01-01'), id: '1' } as Job,
+        { postedDate: new Date('2024-03-01'), id: '2' } as Job,
+        { postedDate: new Date('2024-02-01'), id: '3' } as Job,
       ];
       
       const sorted = jobService.sortJobsByDate(jobs);

--- a/app/services/jobService.ts
+++ b/app/services/jobService.ts
@@ -109,10 +109,10 @@ export class JobService {
       const daysAgo = Math.floor(Math.random() * 30);
       const postedDate = new Date(now);
       postedDate.setDate(postedDate.getDate() - daysAgo);
-      
+
       return {
         ...job,
-        postedDate: postedDate.toISOString(),
+        postedDate,
       };
     });
   }
@@ -134,8 +134,8 @@ export class JobService {
 
   sortJobsByDate(jobs: Job[]): Job[] {
     return [...jobs].sort((a, b) => {
-      const dateA = new Date(a.postedDate).getTime();
-      const dateB = new Date(b.postedDate).getTime();
+      const dateA = a.postedDate.getTime();
+      const dateB = b.postedDate.getTime();
       return dateB - dateA; // Newest first
     });
   }

--- a/app/types/Job.ts
+++ b/app/types/Job.ts
@@ -6,7 +6,7 @@ export interface Job {
   salary?: string;
   description: string;
   requirements: string[];
-  postedDate: string;
+  postedDate: Date;
   applicationUrl: string;
   logoUrl?: string;
   isRemote: boolean;

--- a/app/utils/__tests__/jobUtils.test.ts
+++ b/app/utils/__tests__/jobUtils.test.ts
@@ -31,7 +31,7 @@ describe('jobUtils', () => {
   describe('isJobNew', () => {
     it('should return true for jobs posted within 7 days', () => {
       const recentJob = createMockJob({
-        postedDate: new Date().toISOString()
+        postedDate: new Date()
       });
       
       expect(isJobNew(recentJob)).toBe(true);
@@ -42,7 +42,7 @@ describe('jobUtils', () => {
       oldDate.setDate(oldDate.getDate() - 10);
       
       const oldJob = createMockJob({
-        postedDate: oldDate.toISOString()
+        postedDate: oldDate
       });
       
       expect(isJobNew(oldJob)).toBe(false);

--- a/app/utils/jobUtils.ts
+++ b/app/utils/jobUtils.ts
@@ -8,7 +8,7 @@ export function createMockJob(overrides?: Partial<Job>): Job {
     location: 'New York, NY',
     description: 'We are looking for a talented developer...',
     requirements: ['React Native', 'TypeScript', 'Jest'],
-    postedDate: new Date().toISOString(),
+    postedDate: new Date(),
     applicationUrl: 'https://example.com/apply',
     isRemote: false,
     employmentType: 'full-time',
@@ -18,7 +18,7 @@ export function createMockJob(overrides?: Partial<Job>): Job {
 }
 
 export function isJobNew(job: Job, daysThreshold: number = 7): boolean {
-  const postedDate = new Date(job.postedDate);
+  const postedDate = job.postedDate;
   const now = new Date();
   const daysDifference =
     (now.getTime() - postedDate.getTime()) / (1000 * 3600 * 24);


### PR DESCRIPTION
## Summary
- change `postedDate` field to `Date`
- update utilities and service methods to work with `Date`
- adjust job service and job utils tests for new type

## Testing
- `npm install`
- `npx jest`
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_6844b8d6eb40832db449b8a9f1f3a762