### PR TITLE
Update navigation typing for ApplicationsScreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Testing
+
+Install dependencies first:
+
+```bash
+npm install
+```
+
+Then run the test suite:
+
+```bash
+npm test
+```
+

--- a/app/screens/ApplicationsScreen.tsx
+++ b/app/screens/ApplicationsScreen.tsx
@@ -8,14 +8,15 @@ import {
   ActivityIndicator,
   RefreshControl,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, NavigationProp } from '@react-navigation/native';
+import { RootStackParamList } from '../navigation/types';
 import { applicationService } from '../services/applicationService';
 import { Application, ApplicationStatus } from '../types/Application';
 
 type FilterType = 'all' | ApplicationStatus;
 
 export const ApplicationsScreen = () => {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
   const [applications, setApplications] = useState<Application[]>([]);
   const [stats, setStats] = useState({
     total: 0,


### PR DESCRIPTION
## Summary
- type `useNavigation` for ApplicationsScreen
- add testing instructions

## Testing
- `npx jest --runInBand --json --outputFile=/tmp/test-results.json`


------
https://chatgpt.com/codex/tasks/task_e_6844b8d99c38832db69d95d6e24dacbd