### PR TITLE
Fix regex escaping for skill counting

### DIFF
--- a/__tests__/services/careerMatchingService.test.ts
+++ b/__tests__/services/careerMatchingService.test.ts
@@ -1,0 +1,269 @@
+import {
+  CareerMatchingService,
+  UserProfile,
+  JobWithVector,
+  CareerTransition
+} from '@/services/careerMatchingService';
+import { createEmptyVector } from '@/services/vectorOperations';
+
+describe('CareerMatchingService', () => {
+  let service: CareerMatchingService;
+
+  beforeEach(() => {
+    service = new CareerMatchingService();
+  });
+
+  describe('parseResume', () => {
+    it('creates user profile from resume text', async () => {
+      const resumeText = `
+        John Doe
+        Senior Software Engineer
+        
+        Experience:
+        - 5 years building web applications with React and Node.js
+        - Led team of 4 developers
+        - Implemented CI/CD pipelines with AWS
+        
+        Skills: JavaScript, Python, AWS, Leadership, Agile
+      `;
+
+      const profile = await service.parseResume(resumeText);
+
+      expect(profile.currentRole).toBe('Software Engineer');
+      expect(profile.yearsExperience).toBe(5);
+      expect(profile.skills).toContain('javascript');
+      expect(profile.skills).toContain('aws');
+      expect(profile.vector.programming).toBeGreaterThan(0.7);
+      expect(profile.vector.leadership).toBeGreaterThan(0.4);
+    });
+
+    it('handles product manager resume', async () => {
+      const resumeText = `
+        Jane Smith
+        Senior Product Manager at Tech Corp
+        
+        8 years experience in product management
+        - Define product roadmap and strategy
+        - Collaborate with engineering and design teams
+        - Analyze user metrics and A/B tests
+        - Previously: Software Developer (3 years)
+      `;
+
+      const profile = await service.parseResume(resumeText);
+
+      expect(profile.currentRole).toBe('Product Manager');
+      expect(profile.yearsExperience).toBe(8);
+      expect(profile.vector.projectManagement).toBeGreaterThan(0.7);
+      expect(profile.vector.communication).toBeGreaterThan(0.6);
+      expect(profile.vector.programming).toBeGreaterThan(0.3); // Past experience
+    });
+  });
+
+  describe('createJobVector', () => {
+    it('creates vector from job description', () => {
+      const jobDescription = `
+        Product Manager - FinTech Startup
+        
+        Requirements:
+        - 5+ years product management experience
+        - Technical background preferred
+        - Experience with financial products
+        - Strong analytical and communication skills
+        - Work with engineering teams
+      `;
+
+      const jobVector = service.createJobVector(jobDescription);
+
+      expect(jobVector.vector.projectManagement).toBeGreaterThan(0.7);
+      expect(jobVector.vector.communication).toBeGreaterThan(0.6);
+      expect(jobVector.vector.finance).toBeGreaterThan(0.5);
+      expect(jobVector.requiredExperience).toBe(5);
+    });
+  });
+
+  describe('getCareerMatches', () => {
+    const userProfile: UserProfile = {
+      id: '1',
+      currentRole: 'Software Engineer',
+      yearsExperience: 5,
+      skills: ['javascript', 'react', 'node.js', 'aws'],
+      vector: {
+        ...createEmptyVector(),
+        programming: 0.9,
+        webDevelopment: 0.8,
+        cloudComputing: 0.6,
+        leadership: 0.3,
+        communication: 0.5,
+        problemSolving: 0.8,
+      },
+      temperature: 0.5, // Moderate pivot
+    };
+
+    const jobs: JobWithVector[] = [
+      {
+        id: '1',
+        title: 'Senior Software Engineer',
+        company: 'Tech Co',
+        vector: {
+          ...createEmptyVector(),
+          programming: 0.95,
+          webDevelopment: 0.85,
+          leadership: 0.4,
+        },
+        requiredExperience: 5,
+      },
+      {
+        id: '2',
+        title: 'Technical Product Manager',
+        company: 'Product Co',
+        vector: {
+          ...createEmptyVector(),
+          programming: 0.4,
+          projectManagement: 0.8,
+          communication: 0.8,
+          leadership: 0.6,
+        },
+        requiredExperience: 4,
+      },
+      {
+        id: '3',
+        title: 'UX Designer',
+        company: 'Design Co',
+        vector: {
+          ...createEmptyVector(),
+          design: 0.9,
+          creativity: 0.8,
+          communication: 0.6,
+        },
+        requiredExperience: 3,
+      },
+      {
+        id: '4',
+        title: 'Sales Manager',
+        company: 'Sales Co',
+        vector: {
+          ...createEmptyVector(),
+          sales: 0.9,
+          communication: 0.9,
+          leadership: 0.7,
+        },
+        requiredExperience: 5,
+      },
+    ];
+
+    it('returns jobs matching temperature preference', () => {
+      const matches = service.getCareerMatches(userProfile, jobs);
+
+      // At temperature 0.5 (pivot), should prefer moderate changes
+      expect(matches).toHaveLength(4);
+      expect(matches[0].title).toBe('Technical Product Manager'); // Best pivot match
+      expect(matches[0].matchScore).toBeGreaterThan(0.7);
+      expect(matches[0].similarity).toBeGreaterThan(0.4);
+      expect(matches[0].similarity).toBeLessThan(0.7);
+    });
+
+    it('returns similar jobs for low temperature', () => {
+      const conservativeProfile = { ...userProfile, temperature: 0.1 };
+      const matches = service.getCareerMatches(conservativeProfile, jobs);
+
+      expect(matches[0].title).toBe('Senior Software Engineer');
+      expect(matches[0].similarity).toBeGreaterThan(0.8);
+    });
+
+    it('returns different jobs for high temperature', () => {
+      const boldProfile = { ...userProfile, temperature: 0.9 };
+      const matches = service.getCareerMatches(boldProfile, jobs);
+
+      // Should prefer very different roles
+      expect(matches[0].title).toBe('Sales Manager');
+      expect(matches[0].similarity).toBeLessThan(0.4);
+    });
+
+    it('includes transferable skills in matches', () => {
+      const matches = service.getCareerMatches(userProfile, jobs);
+      const pmMatch = matches.find(m => m.title === 'Technical Product Manager');
+
+      expect(pmMatch?.transferableSkills).toContain('problem solving');
+      expect(pmMatch?.transferableSkills).toContain('technical knowledge');
+      expect(pmMatch?.skillGaps).toContain('project management');
+    });
+  });
+
+  describe('suggestCareerPaths', () => {
+    it('suggests paths for software developer', () => {
+      const profile: UserProfile = {
+        id: '1',
+        currentRole: 'Software Engineer',
+        yearsExperience: 5,
+        skills: ['javascript', 'react', 'leadership'],
+        vector: {
+          ...createEmptyVector(),
+          programming: 0.9,
+          leadership: 0.4,
+        },
+        temperature: 0.5,
+      };
+
+      const paths = service.suggestCareerPaths(profile);
+
+      expect(paths).toHaveLength(3);
+      expect(paths[0].targetRole).toBe('Technical Lead');
+      expect(paths[1].targetRole).toBe('Product Manager');
+      expect(paths[2].targetRole).toBe('Solutions Architect');
+
+      // Each path should have steps
+      const pmPath = paths.find(p => p.targetRole === 'Product Manager');
+      expect(pmPath?.steps).toContain('Build product thinking skills');
+      expect(pmPath?.estimatedTime).toBe('6-12 months');
+    });
+
+    it('suggests paths based on temperature', () => {
+      const profile: UserProfile = {
+        id: '1',
+        currentRole: 'Software Engineer',
+        yearsExperience: 3,
+        skills: ['python', 'data analysis'],
+        vector: {
+          ...createEmptyVector(),
+          programming: 0.8,
+          dataAnalysis: 0.6,
+        },
+        temperature: 0.8, // Bold move
+      };
+
+      const paths = service.suggestCareerPaths(profile);
+
+      // Should suggest more dramatic transitions
+      expect(paths.some(p => p.targetRole === 'Data Scientist')).toBe(true);
+      expect(paths.some(p => p.targetRole === 'Technical Writer')).toBe(true);
+    });
+  });
+
+  describe('analyzeSkillGaps', () => {
+    it('identifies missing skills for transition', () => {
+      const currentVector = {
+        ...createEmptyVector(),
+        programming: 0.9,
+        webDevelopment: 0.8,
+        leadership: 0.3,
+        communication: 0.5,
+      };
+
+      const targetVector = {
+        ...createEmptyVector(),
+        programming: 0.4,
+        projectManagement: 0.8,
+        leadership: 0.7,
+        communication: 0.8,
+      };
+
+      const gaps = service.analyzeSkillGaps(currentVector, targetVector);
+
+      expect(gaps.missing).toContain('project management');
+      expect(gaps.missing).toContain('leadership');
+      expect(gaps.transferable).toContain('programming');
+      expect(gaps.overallGap).toBeGreaterThan(0.3);
+      expect(gaps.overallGap).toBeLessThan(0.7);
+    });
+  });
+});

--- a/__tests__/services/skillExtraction.test.ts
+++ b/__tests__/services/skillExtraction.test.ts
@@ -1,0 +1,192 @@
+import {
+  extractSkillsFromText,
+  textToVector,
+  extractYearsOfExperience,
+  identifyCurrentRole,
+  SkillKeywords,
+  RoleCategoryMapping
+} from '@/services/skillExtraction';
+import { SkillVector } from '@/services/vectorOperations';
+
+describe('Skill Extraction', () => {
+  describe('extractSkillsFromText', () => {
+    it('extracts programming languages', () => {
+      const text = 'Experienced developer with Python, JavaScript, and React skills.';
+      const skills = extractSkillsFromText(text);
+      
+      expect(skills).toContain('python');
+      expect(skills).toContain('javascript');
+      expect(skills).toContain('react');
+    });
+
+    it('extracts cloud platforms', () => {
+      const text = 'Deployed applications on AWS and Google Cloud Platform';
+      const skills = extractSkillsFromText(text);
+      
+      expect(skills).toContain('aws');
+      expect(skills).toContain('gcp');
+    });
+
+    it('extracts soft skills', () => {
+      const text = 'Led cross-functional teams, excellent communication and project management';
+      const skills = extractSkillsFromText(text);
+      
+      expect(skills).toContain('leadership');
+      expect(skills).toContain('communication');
+      expect(skills).toContain('project management');
+    });
+
+    it('handles case insensitive matching', () => {
+      const text = 'PYTHON developer with AWS experience';
+      const skills = extractSkillsFromText(text);
+      
+      expect(skills).toContain('python');
+      expect(skills).toContain('aws');
+    });
+
+    it('avoids duplicate skills', () => {
+      const text = 'Python Python python PYTHON';
+      const skills = extractSkillsFromText(text);
+      
+      const pythonCount = skills.filter(s => s === 'python').length;
+      expect(pythonCount).toBe(1);
+    });
+  });
+
+  describe('textToVector', () => {
+    it('creates vector with programming skills', () => {
+      const text = 'Senior Python developer with 5 years experience in Django and React';
+      const vector = textToVector(text);
+      
+      expect(vector.programming).toBeGreaterThan(0.7);
+      expect(vector.webDevelopment).toBeGreaterThan(0.6);
+    });
+
+    it('creates vector with leadership skills', () => {
+      const text = 'Engineering Manager leading a team of 10 developers';
+      const vector = textToVector(text);
+      
+      expect(vector.leadership).toBeGreaterThan(0.7);
+      expect(vector.projectManagement).toBeGreaterThan(0.5);
+    });
+
+    it('creates vector with mixed skills', () => {
+      const text = `
+        Full-stack developer transitioning to product management.
+        5 years coding experience, recently completed PM certification.
+        Led feature development and stakeholder communication.
+      `;
+      const vector = textToVector(text);
+      
+      expect(vector.programming).toBeGreaterThan(0.6);
+      expect(vector.projectManagement).toBeGreaterThan(0.5);
+      expect(vector.communication).toBeGreaterThan(0.4);
+    });
+
+    it('weights skills based on frequency and context', () => {
+      const text = `
+        Python Python Python JavaScript
+        Senior Python Developer
+        Built Python applications
+      `;
+      const vector = textToVector(text);
+      
+      // Python mentioned more times, should have higher weight
+      expect(vector.programming).toBeGreaterThan(0.8);
+    });
+
+    it('identifies domain expertise', () => {
+      const text = 'FinTech developer building trading systems for investment banks';
+      const vector = textToVector(text);
+      
+      expect(vector.finance).toBeGreaterThan(0.6);
+    });
+  });
+
+  describe('extractYearsOfExperience', () => {
+    it('extracts years from various formats', () => {
+      expect(extractYearsOfExperience('5 years of experience')).toBe(5);
+      expect(extractYearsOfExperience('10+ years')).toBe(10);
+      expect(extractYearsOfExperience('3-5 years experience')).toBe(4); // Average
+      expect(extractYearsOfExperience('over 7 years')).toBe(7);
+    });
+
+    it('returns 0 when no experience mentioned', () => {
+      expect(extractYearsOfExperience('Fresh graduate')).toBe(0);
+      expect(extractYearsOfExperience('No prior experience')).toBe(0);
+    });
+
+    it('handles experience in months', () => {
+      expect(extractYearsOfExperience('18 months experience')).toBe(1.5);
+      expect(extractYearsOfExperience('6 month internship')).toBe(0.5);
+    });
+  });
+
+  describe('identifyCurrentRole', () => {
+    it('identifies developer roles', () => {
+      expect(identifyCurrentRole('Senior Software Engineer at Google')).toBe('Software Engineer');
+      expect(identifyCurrentRole('Full Stack Developer')).toBe('Full Stack Developer');
+      expect(identifyCurrentRole('Python Developer with AWS')).toBe('Python Developer');
+    });
+
+    it('identifies management roles', () => {
+      expect(identifyCurrentRole('Engineering Manager')).toBe('Engineering Manager');
+      expect(identifyCurrentRole('VP of Engineering')).toBe('VP Engineering');
+      expect(identifyCurrentRole('Product Manager at Meta')).toBe('Product Manager');
+    });
+
+    it('identifies designer roles', () => {
+      expect(identifyCurrentRole('Senior UX Designer')).toBe('UX Designer');
+      expect(identifyCurrentRole('UI/UX Designer')).toBe('UI/UX Designer');
+    });
+
+    it('returns generic role when unclear', () => {
+      expect(identifyCurrentRole('Works at tech company')).toBe('Professional');
+      expect(identifyCurrentRole('')).toBe('Professional');
+    });
+  });
+
+  describe('Skill Keywords', () => {
+    it('has comprehensive programming language coverage', () => {
+      expect(SkillKeywords.programming).toContain('python');
+      expect(SkillKeywords.programming).toContain('javascript');
+      expect(SkillKeywords.programming).toContain('typescript');
+      expect(SkillKeywords.programming).toContain('java');
+      expect(SkillKeywords.programming).toContain('go');
+    });
+
+    it('has cloud platform keywords', () => {
+      expect(SkillKeywords.cloud).toContain('aws');
+      expect(SkillKeywords.cloud).toContain('azure');
+      expect(SkillKeywords.cloud).toContain('gcp');
+      expect(SkillKeywords.cloud).toContain('kubernetes');
+    });
+
+    it('has soft skill keywords', () => {
+      expect(SkillKeywords.leadership).toContain('led');
+      expect(SkillKeywords.leadership).toContain('managed');
+      expect(SkillKeywords.communication).toContain('presented');
+      expect(SkillKeywords.communication).toContain('collaborated');
+    });
+  });
+
+  describe('Role Category Mapping', () => {
+    it('maps developer roles to vector weights', () => {
+      const developerVector = RoleCategoryMapping['developer'];
+      expect(developerVector.programming).toBeGreaterThan(0.7);
+      expect(developerVector.problemSolving).toBeGreaterThan(0.6);
+    });
+
+    it('maps manager roles to vector weights', () => {
+      const managerVector = RoleCategoryMapping['manager'];
+      expect(managerVector.leadership).toBeGreaterThan(0.7);
+      expect(managerVector.projectManagement).toBeGreaterThan(0.6);
+    });
+
+    it('maps designer roles to vector weights', () => {
+      const designerVector = RoleCategoryMapping['designer'];
+      expect(designerVector.design).toBeGreaterThan(0.8);
+      expect(designerVector.creativity).toBeGreaterThan(0.7);
+    });
+  });
+});

--- a/__tests__/services/vectorOperations.test.ts
+++ b/__tests__/services/vectorOperations.test.ts
@@ -1,0 +1,224 @@
+import {
+  createEmptyVector,
+  normalizeVector,
+  cosineSimilarity,
+  vectorDistance,
+  addVectors,
+  scaleVector,
+  SkillVector
+} from '@/services/vectorOperations';
+
+describe('Vector Operations', () => {
+  describe('createEmptyVector', () => {
+    it('creates a vector with all zero values', () => {
+      const vector = createEmptyVector();
+      
+      expect(vector.programming).toBe(0);
+      expect(vector.leadership).toBe(0);
+      expect(vector.communication).toBe(0);
+      expect(Object.values(vector).every(v => v === 0)).toBe(true);
+    });
+
+    it('has all required skill dimensions', () => {
+      const vector = createEmptyVector();
+      const requiredDimensions = [
+        'programming', 'dataAnalysis', 'cloudComputing', 'machineLearning',
+        'webDevelopment', 'mobileDevelopment', 'devOps', 'databases',
+        'leadership', 'communication', 'projectManagement', 'teamwork',
+        'problemSolving', 'creativity', 'sales', 'marketing',
+        'writing', 'teaching', 'design', 'research',
+        'finance', 'healthcare', 'retail', 'manufacturing',
+        'education', 'government', 'nonprofit', 'startup'
+      ];
+
+      requiredDimensions.forEach(dim => {
+        expect(vector).toHaveProperty(dim);
+        expect(typeof vector[dim]).toBe('number');
+      });
+    });
+  });
+
+  describe('normalizeVector', () => {
+    it('normalizes a vector to unit length', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 3;
+      vector.leadership = 4; // 3-4-5 triangle
+
+      const normalized = normalizeVector(vector);
+      
+      // Magnitude should be 1
+      const magnitude = Math.sqrt(
+        Object.values(normalized).reduce((sum, val) => sum + val * val, 0)
+      );
+      expect(magnitude).toBeCloseTo(1, 5);
+    });
+
+    it('handles zero vectors', () => {
+      const vector = createEmptyVector();
+      const normalized = normalizeVector(vector);
+      
+      expect(Object.values(normalized).every(v => v === 0)).toBe(true);
+    });
+
+    it('preserves relative proportions', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 0.8;
+      vector.leadership = 0.4;
+
+      const normalized = normalizeVector(vector);
+      const ratio = normalized.programming / normalized.leadership;
+      
+      expect(ratio).toBeCloseTo(2, 5);
+    });
+  });
+
+  describe('cosineSimilarity', () => {
+    it('returns 1 for identical vectors', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 0.8;
+      vector.leadership = 0.6;
+
+      const similarity = cosineSimilarity(vector, vector);
+      expect(similarity).toBeCloseTo(1, 5);
+    });
+
+    it('returns 0 for orthogonal vectors', () => {
+      const vector1: SkillVector = createEmptyVector();
+      vector1.programming = 1;
+
+      const vector2: SkillVector = createEmptyVector();
+      vector2.leadership = 1;
+
+      const similarity = cosineSimilarity(vector1, vector2);
+      expect(similarity).toBeCloseTo(0, 5);
+    });
+
+    it('returns negative values for opposite vectors', () => {
+      const vector1: SkillVector = createEmptyVector();
+      vector1.programming = 1;
+
+      const vector2: SkillVector = createEmptyVector();
+      vector2.programming = -1;
+
+      const similarity = cosineSimilarity(vector1, vector2);
+      expect(similarity).toBeCloseTo(-1, 5);
+    });
+
+    it('calculates correct similarity for similar roles', () => {
+      // Software Developer vector
+      const developer: SkillVector = createEmptyVector();
+      developer.programming = 0.9;
+      developer.webDevelopment = 0.8;
+      developer.databases = 0.7;
+      developer.problemSolving = 0.8;
+
+      // Senior Developer vector (very similar)
+      const seniorDev: SkillVector = createEmptyVector();
+      seniorDev.programming = 0.95;
+      seniorDev.webDevelopment = 0.85;
+      seniorDev.databases = 0.8;
+      seniorDev.problemSolving = 0.85;
+      seniorDev.leadership = 0.4;
+
+      const similarity = cosineSimilarity(developer, seniorDev);
+      expect(similarity).toBeGreaterThan(0.9);
+    });
+
+    it('calculates correct similarity for pivot roles', () => {
+      // Software Developer vector
+      const developer: SkillVector = createEmptyVector();
+      developer.programming = 0.9;
+      developer.webDevelopment = 0.8;
+      developer.problemSolving = 0.8;
+
+      // Product Manager vector (moderate pivot)
+      const productManager: SkillVector = createEmptyVector();
+      productManager.programming = 0.3;
+      productManager.communication = 0.9;
+      productManager.projectManagement = 0.8;
+      productManager.leadership = 0.7;
+      productManager.problemSolving = 0.8; // Shared skill
+
+      const similarity = cosineSimilarity(developer, productManager);
+      expect(similarity).toBeGreaterThan(0.3);
+      expect(similarity).toBeLessThan(0.7);
+    });
+  });
+
+  describe('vectorDistance', () => {
+    it('returns 0 for identical vectors', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 0.5;
+      vector.leadership = 0.5;
+
+      const distance = vectorDistance(vector, vector);
+      expect(distance).toBe(0);
+    });
+
+    it('calculates Euclidean distance correctly', () => {
+      const vector1: SkillVector = createEmptyVector();
+      vector1.programming = 1;
+
+      const vector2: SkillVector = createEmptyVector();
+      vector2.programming = 0;
+      vector2.leadership = 1;
+
+      // Distance should be sqrt(1^2 + 1^2) = sqrt(2)
+      const distance = vectorDistance(vector1, vector2);
+      expect(distance).toBeCloseTo(Math.sqrt(2), 5);
+    });
+  });
+
+  describe('addVectors', () => {
+    it('adds two vectors correctly', () => {
+      const vector1: SkillVector = createEmptyVector();
+      vector1.programming = 0.5;
+      vector1.leadership = 0.3;
+
+      const vector2: SkillVector = createEmptyVector();
+      vector2.programming = 0.3;
+      vector2.communication = 0.4;
+
+      const result = addVectors(vector1, vector2);
+      expect(result.programming).toBeCloseTo(0.8, 5);
+      expect(result.leadership).toBeCloseTo(0.3, 5);
+      expect(result.communication).toBeCloseTo(0.4, 5);
+    });
+
+    it('handles empty vectors', () => {
+      const vector1 = createEmptyVector();
+      const vector2 = createEmptyVector();
+
+      const result = addVectors(vector1, vector2);
+      expect(Object.values(result).every(v => v === 0)).toBe(true);
+    });
+  });
+
+  describe('scaleVector', () => {
+    it('scales a vector by a constant', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 0.5;
+      vector.leadership = 0.4;
+
+      const scaled = scaleVector(vector, 2);
+      expect(scaled.programming).toBeCloseTo(1.0, 5);
+      expect(scaled.leadership).toBeCloseTo(0.8, 5);
+    });
+
+    it('handles zero scaling', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 0.5;
+
+      const scaled = scaleVector(vector, 0);
+      expect(Object.values(scaled).every(v => v === 0)).toBe(true);
+    });
+
+    it('handles negative scaling', () => {
+      const vector: SkillVector = createEmptyVector();
+      vector.programming = 0.5;
+
+      const scaled = scaleVector(vector, -1);
+      expect(scaled.programming).toBeCloseTo(-0.5, 5);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,14 +4,19 @@
   "version": "1.0.0",
   "scripts": {
     "start": "expo start",
-    "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "test:temperature": "jest __tests__/components/TemperatureSlider.test.tsx __tests__/services/temperatureMatching.test.ts",
+    "test:vectors": "jest __tests__/services/vectorOperations.test.ts __tests__/services/skillExtraction.test.ts __tests__/services/careerMatchingService.test.ts --coverage",
+    "test:vector:watch": "jest __tests__/services/vector*.test.ts __tests__/services/skill*.test.ts __tests__/services/career*.test.ts --watch",
+    "test:all": "jest --coverage --verbose",
+    "lint": "eslint . --ext .ts,.tsx",
+    "format": "prettier --write \"**/*.{ts,tsx,json}\"",
+    "reset-project": "node ./scripts/reset-project.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/services/careerMatchingService.ts
+++ b/services/careerMatchingService.ts
@@ -1,0 +1,327 @@
+import {
+  SkillVector,
+  createEmptyVector,
+  cosineSimilarity,
+  normalizeVector,
+  vectorDistance
+} from './vectorOperations';
+import {
+  extractSkillsFromText,
+  textToVector,
+  extractYearsOfExperience,
+  identifyCurrentRole
+} from './skillExtraction';
+
+export interface UserProfile {
+  id: string;
+  currentRole: string;
+  yearsExperience: number;
+  skills: string[];
+  vector: SkillVector;
+  temperature: number; // 0-1, how different they want roles to be
+}
+
+export interface JobWithVector {
+  id: string;
+  title: string;
+  company: string;
+  vector: SkillVector;
+  requiredExperience: number;
+  description?: string;
+  location?: string;
+  salary?: string;
+}
+
+export interface CareerMatch extends JobWithVector {
+  similarity: number;
+  matchScore: number; // Adjusted for temperature preference
+  transferableSkills: string[];
+  skillGaps: string[];
+  transitionDifficulty: 'Easy' | 'Moderate' | 'Challenging' | 'Difficult';
+}
+
+export interface CareerTransition {
+  targetRole: string;
+  similarity: number;
+  steps: string[];
+  estimatedTime: string;
+  difficulty: string;
+}
+
+export interface SkillGapAnalysis {
+  missing: string[];
+  transferable: string[];
+  overallGap: number;
+}
+
+export class CareerMatchingService {
+  /**
+   * Parse resume text into a user profile with skill vector
+   */
+  async parseResume(resumeText: string): Promise<UserProfile> {
+    const skills = extractSkillsFromText(resumeText);
+    const vector = textToVector(resumeText);
+    const currentRole = identifyCurrentRole(resumeText);
+    const yearsExperience = extractYearsOfExperience(resumeText);
+
+    return {
+      id: Date.now().toString(),
+      currentRole,
+      yearsExperience,
+      skills,
+      vector: normalizeVector(vector),
+      temperature: 0.5, // Default to moderate pivot
+    };
+  }
+
+  /**
+   * Create job vector from job description
+   */
+  createJobVector(jobDescription: string): JobWithVector {
+    const vector = textToVector(jobDescription);
+    const requiredExperience = extractYearsOfExperience(jobDescription);
+
+    // Extract title from description (simplified)
+    const titleMatch = jobDescription.match(/^([^\n]+)/);
+    const title = titleMatch ? titleMatch[1].trim() : 'Unknown Position';
+
+    return {
+      id: Date.now().toString(),
+      title,
+      company: 'Company',
+      vector: normalizeVector(vector),
+      requiredExperience,
+      description: jobDescription,
+    };
+  }
+
+  /**
+   * Get career matches based on user profile and temperature
+   */
+  getCareerMatches(
+    profile: UserProfile,
+    availableJobs: JobWithVector[]
+  ): CareerMatch[] {
+    // Calculate similarity and match scores for all jobs
+    const matches = availableJobs.map(job => {
+      const similarity = cosineSimilarity(profile.vector, job.vector);
+      const matchScore = this.calculateMatchScore(similarity, profile.temperature);
+      const { transferableSkills, skillGaps } = this.analyzeTransition(
+        profile,
+        job
+      );
+      const transitionDifficulty = this.assessTransitionDifficulty(similarity);
+
+      return {
+        ...job,
+        similarity,
+        matchScore,
+        transferableSkills,
+        skillGaps,
+        transitionDifficulty,
+      };
+    });
+
+    // Sort by match score (higher is better)
+    return matches.sort((a, b) => b.matchScore - a.matchScore);
+  }
+
+  /**
+   * Calculate match score based on similarity and temperature preference
+   */
+  private calculateMatchScore(similarity: number, temperature: number): number {
+    // Temperature determines the "sweet spot" for similarity
+    // Low temp (0): prefer high similarity (0.8-1.0)
+    // Medium temp (0.5): prefer moderate similarity (0.4-0.7)
+    // High temp (1): prefer low similarity (0.1-0.4)
+    
+    const targetSimilarity = 0.9 - temperature * 0.7;
+    const variance = 1.5;
+
+    const distance = Math.abs(similarity - targetSimilarity);
+    const score = Math.max(0, 1 - distance / variance);
+    
+    return score;
+  }
+
+  /**
+   * Analyze what skills transfer and what gaps exist
+   */
+  private analyzeTransition(
+    profile: UserProfile,
+    job: JobWithVector
+  ): { transferableSkills: string[]; skillGaps: string[] } {
+    const transferableSkills: string[] = [];
+    const skillGaps: string[] = [];
+
+    // Define skill categories and thresholds
+    const skillCategories = [
+      { name: 'programming', label: 'technical knowledge' },
+      { name: 'leadership', label: 'leadership' },
+      { name: 'communication', label: 'communication' },
+      { name: 'projectManagement', label: 'project management' },
+      { name: 'problemSolving', label: 'problem solving' },
+      { name: 'dataAnalysis', label: 'analytical skills' },
+    ];
+
+    skillCategories.forEach(({ name, label }) => {
+      const userSkill = profile.vector[name] || 0;
+      const jobRequirement = job.vector[name] || 0;
+
+      if (userSkill > 0.3 && jobRequirement > 0.3) {
+        transferableSkills.push(label);
+      } else if (userSkill < 0.3 && jobRequirement > 0.5) {
+        skillGaps.push(label);
+      }
+    });
+
+    return { transferableSkills, skillGaps };
+  }
+
+  /**
+   * Assess how difficult a career transition would be
+   */
+  private assessTransitionDifficulty(
+    similarity: number
+  ): 'Easy' | 'Moderate' | 'Challenging' | 'Difficult' {
+    if (similarity > 0.8) return 'Easy';
+    if (similarity > 0.6) return 'Moderate';
+    if (similarity > 0.4) return 'Challenging';
+    return 'Difficult';
+  }
+
+  /**
+   * Suggest specific career paths based on profile
+   */
+  suggestCareerPaths(profile: UserProfile): CareerTransition[] {
+    const paths: CareerTransition[] = [];
+
+    // Software Engineer paths
+    if (profile.currentRole.includes('Software Engineer') || 
+        profile.currentRole.includes('Developer')) {
+      
+      if (profile.temperature < 0.3) {
+        // Conservative transitions
+        paths.push({
+          targetRole: 'Technical Lead',
+          similarity: 0.85,
+          steps: [
+            'Mentor junior developers',
+            'Lead technical design discussions',
+            'Own larger technical initiatives',
+          ],
+          estimatedTime: '6-12 months',
+          difficulty: 'Easy',
+        });
+      }
+
+      if (profile.temperature >= 0.3 && profile.temperature < 0.7) {
+        // Moderate pivots
+        paths.push({
+          targetRole: 'Product Manager',
+          similarity: 0.55,
+          steps: [
+            'Build product thinking skills',
+            'Work closely with PMs on feature definition',
+            'Take a PM course or certification',
+            'Lead a small product initiative',
+          ],
+          estimatedTime: '6-12 months',
+          difficulty: 'Moderate',
+        });
+
+        paths.push({
+          targetRole: 'Solutions Architect',
+          similarity: 0.65,
+          steps: [
+            'Deepen system design knowledge',
+            'Get cloud certifications (AWS/Azure)',
+            'Work on customer-facing projects',
+          ],
+          estimatedTime: '3-6 months',
+          difficulty: 'Moderate',
+        });
+      }
+
+      if (profile.temperature >= 0.7) {
+        // Bold transitions
+        if (profile.vector.dataAnalysis > 0.4) {
+          paths.push({
+            targetRole: 'Data Scientist',
+            similarity: 0.45,
+            steps: [
+              'Study statistics and machine learning',
+              'Complete data science bootcamp',
+              'Build ML portfolio projects',
+              'Contribute to data initiatives at work',
+            ],
+            estimatedTime: '12-18 months',
+            difficulty: 'Challenging',
+          });
+        }
+
+        paths.push({
+          targetRole: 'Technical Writer',
+          similarity: 0.35,
+          steps: [
+            'Start technical blog',
+            'Contribute to documentation',
+            'Take technical writing course',
+            'Freelance writing projects',
+          ],
+          estimatedTime: '6-9 months',
+          difficulty: 'Challenging',
+        });
+      }
+    }
+
+    // Add PM paths, Designer paths, etc. based on current role
+
+    return paths.slice(0, 3); // Return top 3 suggestions
+  }
+
+  /**
+   * Analyze skill gaps between current and target vectors
+   */
+  analyzeSkillGaps(
+    currentVector: SkillVector,
+    targetVector: SkillVector
+  ): SkillGapAnalysis {
+    const missing: string[] = [];
+    const transferable: string[] = [];
+
+    const skillMap: Record<string, string> = {
+      programming: 'programming',
+      projectManagement: 'project management',
+      leadership: 'leadership',
+      communication: 'communication',
+      dataAnalysis: 'data analysis',
+      design: 'design',
+      sales: 'sales',
+      marketing: 'marketing',
+    };
+
+    Object.entries(skillMap).forEach(([key, label]) => {
+      const current = currentVector[key] || 0;
+      const target = targetVector[key] || 0;
+
+      if (target > 0.5 && current < 0.3) {
+        missing.push(label);
+      } else if (current > 0.4 && target > 0.3) {
+        transferable.push(label);
+      }
+    });
+
+    const overallGap = vectorDistance(currentVector, targetVector) / 
+                      Math.sqrt(Object.keys(currentVector).length);
+
+    return {
+      missing,
+      transferable,
+      overallGap: Math.min(1, overallGap),
+    };
+  }
+}
+
+// Export singleton instance
+export const careerMatchingService = new CareerMatchingService();

--- a/services/jobService.ts
+++ b/services/jobService.ts
@@ -1,0 +1,320 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Job } from '@/types';
+import { createEmptyVector, SkillVector } from './vectorOperations';
+import { careerMatchingService, JobWithVector } from './careerMatchingService';
+
+// Mock user profile for MVP (in production, this would come from parsed resume)
+const mockUserProfile = {
+  id: '1',
+  currentRole: 'Software Engineer',
+  yearsExperience: 5,
+  skills: ['javascript', 'react', 'node.js', 'aws'],
+  vector: {
+    ...createEmptyVector(),
+    programming: 0.9,
+    webDevelopment: 0.8,
+    cloudComputing: 0.6,
+    leadership: 0.3,
+    communication: 0.5,
+    problemSolving: 0.8,
+    teamwork: 0.6,
+  },
+  temperature: 0.5,
+};
+
+// Enhanced mock jobs with vectors
+const vectorizedJobs: JobWithVector[] = [
+  // Similar roles (high similarity)
+  {
+    id: '1',
+    title: 'Senior Software Engineer',
+    company: 'TechCorp',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.95,
+      webDevelopment: 0.85,
+      cloudComputing: 0.7,
+      leadership: 0.4,
+      problemSolving: 0.85,
+    },
+    requiredExperience: 5,
+  },
+  {
+    id: '2',
+    title: 'Full Stack Developer',
+    company: 'StartupXYZ',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.85,
+      webDevelopment: 0.9,
+      databases: 0.7,
+      problemSolving: 0.8,
+    },
+    requiredExperience: 4,
+  },
+  
+  // Moderate pivots
+  {
+    id: '3',
+    title: 'Technical Product Manager',
+    company: 'ProductCo',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.4,
+      projectManagement: 0.8,
+      communication: 0.8,
+      leadership: 0.6,
+      problemSolving: 0.7,
+    },
+    requiredExperience: 4,
+  },
+  {
+    id: '4',
+    title: 'DevOps Engineer',
+    company: 'CloudFirst',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.7,
+      cloudComputing: 0.9,
+      devOps: 0.95,
+      problemSolving: 0.8,
+    },
+    requiredExperience: 3,
+  },
+  {
+    id: '5',
+    title: 'Solutions Architect',
+    company: 'Enterprise Inc',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.6,
+      cloudComputing: 0.8,
+      communication: 0.7,
+      leadership: 0.5,
+      problemSolving: 0.9,
+    },
+    requiredExperience: 6,
+  },
+  
+  // Significant pivots
+  {
+    id: '6',
+    title: 'Data Scientist',
+    company: 'DataDriven',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.7,
+      dataAnalysis: 0.9,
+      machineLearning: 0.8,
+      research: 0.7,
+      problemSolving: 0.85,
+    },
+    requiredExperience: 3,
+  },
+  {
+    id: '7',
+    title: 'UX Engineer',
+    company: 'DesignTech',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.5,
+      webDevelopment: 0.6,
+      design: 0.7,
+      creativity: 0.6,
+      problemSolving: 0.6,
+    },
+    requiredExperience: 3,
+  },
+  
+  // Bold pivots
+  {
+    id: '8',
+    title: 'Technical Writer',
+    company: 'DocuCorp',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.3,
+      writing: 0.9,
+      communication: 0.9,
+      research: 0.6,
+    },
+    requiredExperience: 2,
+  },
+  {
+    id: '9',
+    title: 'Developer Relations',
+    company: 'APIFirst',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.5,
+      communication: 0.9,
+      writing: 0.7,
+      teaching: 0.8,
+      marketing: 0.4,
+    },
+    requiredExperience: 4,
+  },
+  {
+    id: '10',
+    title: 'Sales Engineer',
+    company: 'SalesTech',
+    vector: {
+      ...createEmptyVector(),
+      programming: 0.4,
+      communication: 0.8,
+      sales: 0.7,
+      problemSolving: 0.6,
+    },
+    requiredExperience: 3,
+  },
+];
+
+class JobService {
+  private REJECTED_JOBS_KEY = 'rejected_jobs';
+  private USER_PROFILE_KEY = 'user_profile';
+
+  async fetchJobs(temperature?: number): Promise<Job[]> {
+    // Get user profile (mock for now)
+    const userProfile = { ...mockUserProfile, temperature: temperature || 0.5 };
+    
+    // Get rejected job IDs
+    const rejectedIds = await this.getRejectedJobIds();
+    
+    // Filter out rejected jobs
+    const availableJobs = vectorizedJobs.filter(job => !rejectedIds.includes(job.id));
+    
+    // Get career matches using the matching service
+    const matches = careerMatchingService.getCareerMatches(userProfile, availableJobs);
+    
+    // Convert to Job type with similarity scores
+    return matches.map(match => ({
+      id: match.id,
+      company: match.company,
+      title: match.title,
+      location: this.getRandomLocation(),
+      salary: this.getRandomSalary(match.requiredExperience),
+      description: this.generateDescription(match),
+      requirements: this.generateRequirements(match),
+      benefits: this.getRandomBenefits(),
+      postedDate: this.getRandomPostedDate(),
+      url: `https://example.com/jobs/${match.id}`,
+      logo: `https://picsum.photos/seed/${match.company}/100`,
+      isRemote: Math.random() > 0.5,
+      employmentType: 'Full-time' as const,
+      experienceLevel: this.getExperienceLevel(match.requiredExperience),
+      similarity: match.similarity,
+    }));
+  }
+
+  private generateDescription(match: JobWithVector): string {
+    const { transferableSkills, skillGaps, transitionDifficulty } = 
+      careerMatchingService.getCareerMatches(mockUserProfile, [match])[0];
+    
+    let description = `Join us as a ${match.title} at ${match.company}. `;
+    
+    if (transferableSkills.length > 0) {
+      description += `Your experience with ${transferableSkills.join(', ')} will be valuable in this role. `;
+    }
+    
+    if (skillGaps.length > 0) {
+      description += `This role will help you develop ${skillGaps.join(', ')}. `;
+    }
+    
+    description += `Career transition difficulty: ${transitionDifficulty}.`;
+    
+    return description;
+  }
+
+  private generateRequirements(job: JobWithVector): string[] {
+    const requirements: string[] = [];
+    
+    if (job.vector.programming > 0.7) {
+      requirements.push('Strong programming skills');
+    }
+    if (job.vector.projectManagement > 0.6) {
+      requirements.push('Project management experience');
+    }
+    if (job.vector.communication > 0.7) {
+      requirements.push('Excellent communication skills');
+    }
+    if (job.vector.leadership > 0.6) {
+      requirements.push('Leadership experience');
+    }
+    if (job.requiredExperience > 0) {
+      requirements.push(`${job.requiredExperience}+ years experience`);
+    }
+    
+    return requirements.length > 0 ? requirements : ['Passion for learning'];
+  }
+
+  private getExperienceLevel(years: number): 'Entry' | 'Mid' | 'Senior' | 'Lead' {
+    if (years <= 2) return 'Entry';
+    if (years <= 5) return 'Mid';
+    if (years <= 8) return 'Senior';
+    return 'Lead';
+  }
+
+  private getRandomLocation(): string {
+    const locations = [
+      'San Francisco, CA',
+      'New York, NY',
+      'Austin, TX',
+      'Seattle, WA',
+      'Remote',
+      'Chicago, IL',
+      'Boston, MA',
+    ];
+    return locations[Math.floor(Math.random() * locations.length)];
+  }
+
+  private getRandomSalary(experience: number): string {
+    const base = 80000 + (experience * 15000);
+    const min = base + Math.floor(Math.random() * 20000);
+    const max = min + 20000 + Math.floor(Math.random() * 30000);
+    return `$${(min/1000).toFixed(0)}k - $${(max/1000).toFixed(0)}k`;
+  }
+
+  private getRandomBenefits(): string[] {
+    const allBenefits = [
+      'Health insurance',
+      '401k matching',
+      'Unlimited PTO',
+      'Remote work',
+      'Stock options',
+      'Learning budget',
+      'Gym membership',
+      'Free lunch',
+    ];
+    
+    const count = 3 + Math.floor(Math.random() * 3);
+    return allBenefits.sort(() => Math.random() - 0.5).slice(0, count);
+  }
+
+  private getRandomPostedDate(): string {
+    const daysAgo = Math.floor(Math.random() * 30);
+    const date = new Date();
+    date.setDate(date.getDate() - daysAgo);
+    return date.toISOString();
+  }
+
+  async rejectJob(jobId: string): Promise<void> {
+    const rejectedIds = await this.getRejectedJobIds();
+    rejectedIds.push(jobId);
+    await AsyncStorage.setItem(this.REJECTED_JOBS_KEY, JSON.stringify(rejectedIds));
+  }
+
+  private async getRejectedJobIds(): Promise<string[]> {
+    try {
+      const stored = await AsyncStorage.getItem(this.REJECTED_JOBS_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async clearRejectedJobs(): Promise<void> {
+    await AsyncStorage.removeItem(this.REJECTED_JOBS_KEY);
+  }
+}
+
+export const jobService = new JobService();

--- a/services/skillExtraction.ts
+++ b/services/skillExtraction.ts
@@ -1,0 +1,280 @@
+import { SkillVector, createEmptyVector } from './vectorOperations';
+
+// Comprehensive skill keywords mapping
+export const SkillKeywords = {
+  programming: [
+    'python', 'javascript', 'typescript', 'java', 'c++', 'c#', 'ruby', 'go', 'rust',
+    'swift', 'kotlin', 'php', 'scala', 'r', 'matlab', 'perl', 'bash', 'sql'
+  ],
+  webDevelopment: [
+    'react', 'angular', 'vue', 'node.js', 'express', 'django', 'flask', 'rails',
+    'spring', 'html', 'css', 'sass', 'webpack', 'next.js', 'nuxt', 'gatsby'
+  ],
+  mobileDevelopment: [
+    'react native', 'flutter', 'swift', 'swiftui', 'kotlin', 'android', 'ios',
+    'xamarin', 'ionic', 'cordova'
+  ],
+  cloud: [
+    'aws', 'azure', 'gcp', 'google cloud', 'kubernetes', 'docker', 'terraform',
+    'jenkins', 'ci/cd', 'devops', 'microservices', 'serverless', 'lambda'
+  ],
+  data: [
+    'machine learning', 'deep learning', 'tensorflow', 'pytorch', 'scikit-learn',
+    'pandas', 'numpy', 'data analysis', 'data science', 'statistics', 'tableau',
+    'power bi', 'sql', 'bigquery', 'spark', 'hadoop'
+  ],
+  leadership: [
+    'led', 'managed', 'director', 'head of', 'vp', 'chief', 'senior', 'principal',
+    'team lead', 'manager', 'supervised', 'mentored', 'coached', 'guided'
+  ],
+  communication: [
+    'presented', 'collaborated', 'stakeholder', 'client', 'customer', 'negotiated',
+    'facilitated', 'coordinated', 'liaised', 'communicated', 'articulated'
+  ],
+  projectManagement: [
+    'project management', 'agile', 'scrum', 'kanban', 'jira', 'roadmap',
+    'timeline', 'milestone', 'deliverable', 'budget', 'resource', 'planning'
+  ],
+  finance: [
+    'fintech', 'banking', 'trading', 'investment', 'financial', 'accounting',
+    'budget', 'revenue', 'profit', 'blockchain', 'cryptocurrency', 'payments'
+  ],
+  healthcare: [
+    'healthcare', 'medical', 'clinical', 'patient', 'hospital', 'pharma',
+    'biotech', 'diagnosis', 'treatment', 'health', 'hipaa', 'ehr'
+  ],
+};
+
+// Role category to vector mapping
+export const RoleCategoryMapping: Record<string, Partial<SkillVector>> = {
+  developer: {
+    programming: 0.9,
+    webDevelopment: 0.7,
+    databases: 0.6,
+    problemSolving: 0.8,
+    teamwork: 0.5,
+  },
+  manager: {
+    leadership: 0.8,
+    projectManagement: 0.8,
+    communication: 0.7,
+    teamwork: 0.6,
+    problemSolving: 0.6,
+  },
+  designer: {
+    design: 0.9,
+    creativity: 0.8,
+    communication: 0.6,
+    problemSolving: 0.6,
+    webDevelopment: 0.4,
+  },
+  dataScientist: {
+    dataAnalysis: 0.9,
+    machineLearning: 0.8,
+    programming: 0.7,
+    problemSolving: 0.8,
+    research: 0.7,
+  },
+  productManager: {
+    projectManagement: 0.8,
+    communication: 0.8,
+    leadership: 0.6,
+    problemSolving: 0.7,
+    research: 0.6,
+  },
+};
+
+/**
+ * Extract skills from text (resume, job description, etc.)
+ */
+export function extractSkillsFromText(text: string): string[] {
+  const lowerText = text.toLowerCase();
+  const foundSkills = new Set<string>();
+
+  // Check each skill category
+  Object.entries(SkillKeywords).forEach(([category, keywords]) => {
+    keywords.forEach(keyword => {
+      // Use word boundaries for more accurate matching
+      const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(`\\b${escaped}\\b`, 'i');
+      if (regex.test(lowerText)) {
+        foundSkills.add(keyword);
+      }
+    });
+  });
+
+  // Extract soft skills based on context
+  if (/\b(led|managed|supervised)\b/i.test(lowerText)) {
+    foundSkills.add('leadership');
+  }
+  if (/\b(communicat|present|collaborat)/i.test(lowerText)) {
+    foundSkills.add('communication');
+  }
+  if (/\bproject\s+manag/i.test(lowerText)) {
+    foundSkills.add('project management');
+  }
+
+  return Array.from(foundSkills);
+}
+
+/**
+ * Convert text to skill vector
+ */
+export function textToVector(text: string): SkillVector {
+  const vector = createEmptyVector();
+  const lowerText = text.toLowerCase();
+  const skills = extractSkillsFromText(text);
+
+  // Count skill mentions for weighting
+  const skillCounts: Record<string, number> = {};
+  skills.forEach(skill => {
+    const escapedSkill = skill.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const regex = new RegExp(`\\b${escapedSkill}\\b`, 'gi');
+    const matches = lowerText.match(regex);
+    skillCounts[skill] = matches ? matches.length : 1;
+  });
+
+  // Programming skills
+  const programmingSkills = skills.filter(s => 
+    SkillKeywords.programming.includes(s)
+  );
+  if (programmingSkills.length > 0) {
+    vector.programming = Math.min(0.9, 0.3 + programmingSkills.length * 0.15);
+  }
+
+  // Web development
+  const webSkills = skills.filter(s => 
+    SkillKeywords.webDevelopment.includes(s)
+  );
+  if (webSkills.length > 0) {
+    vector.webDevelopment = Math.min(0.9, 0.3 + webSkills.length * 0.15);
+  }
+
+  // Cloud/DevOps
+  const cloudSkills = skills.filter(s => 
+    SkillKeywords.cloud.includes(s)
+  );
+  if (cloudSkills.length > 0) {
+    vector.cloudComputing = Math.min(0.8, 0.3 + cloudSkills.length * 0.1);
+    vector.devOps = Math.min(0.7, 0.2 + cloudSkills.length * 0.1);
+  }
+
+  // Data/ML
+  const dataSkills = skills.filter(s => 
+    SkillKeywords.data.includes(s)
+  );
+  if (dataSkills.length > 0) {
+    vector.dataAnalysis = Math.min(0.9, 0.3 + dataSkills.length * 0.15);
+    if (skills.includes('machine learning') || skills.includes('deep learning')) {
+      vector.machineLearning = 0.8;
+    }
+  }
+
+  // Leadership
+  const leadershipKeywords = SkillKeywords.leadership;
+  const leadershipScore = leadershipKeywords.reduce((score, keyword) => {
+    return lowerText.includes(keyword) ? score + 0.15 : score;
+  }, 0);
+  vector.leadership = Math.min(0.9, leadershipScore);
+
+  // Communication
+  if (skills.includes('communication') || /communicat/i.test(text)) {
+    vector.communication = 0.6;
+    if (/excellent\s+communication/i.test(text)) {
+      vector.communication = 0.8;
+    }
+  }
+
+  // Project Management
+  if (skills.includes('project management') || /project\s+manag/i.test(text)) {
+    vector.projectManagement = 0.7;
+  }
+
+  // Domain expertise
+  if (SkillKeywords.finance.some(keyword => lowerText.includes(keyword))) {
+    vector.finance = 0.7;
+  }
+  if (SkillKeywords.healthcare.some(keyword => lowerText.includes(keyword))) {
+    vector.healthcare = 0.7;
+  }
+
+  // General skills based on context
+  vector.problemSolving = 0.5; // Default for most tech roles
+  vector.teamwork = 0.5; // Default for most roles
+
+  // Boost based on seniority indicators
+  if (/senior|lead|principal|staff/i.test(text)) {
+    vector.leadership = Math.min(0.9, vector.leadership + 0.2);
+    vector.problemSolving = Math.min(0.9, vector.problemSolving + 0.2);
+  }
+
+  return vector;
+}
+
+/**
+ * Extract years of experience from text
+ */
+export function extractYearsOfExperience(text: string): number {
+  // Match patterns like "5 years", "3-5 years", "10+ years"
+  const yearPatterns = [
+    /(\d+)\+?\s*years?/i,
+    /(\d+)-(\d+)\s*years?/i,
+    /over\s+(\d+)\s*years?/i,
+  ];
+
+  for (const pattern of yearPatterns) {
+    const match = text.match(pattern);
+    if (match) {
+      if (match[2]) {
+        // Range like "3-5 years" - return average
+        return (parseInt(match[1]) + parseInt(match[2])) / 2;
+      }
+      return parseInt(match[1]);
+    }
+  }
+
+  // Check for months
+  const monthPattern = /(\d+)\s*months?/i;
+  const monthMatch = text.match(monthPattern);
+  if (monthMatch) {
+    return parseInt(monthMatch[1]) / 12;
+  }
+
+  // No experience mentioned or explicitly stated
+  if (/no\s+(prior\s+)?experience|fresh\s+graduate/i.test(text)) {
+    return 0;
+  }
+
+  return 0;
+}
+
+/**
+ * Identify current role from text
+ */
+export function identifyCurrentRole(text: string): string {
+  const rolePatterns = [
+    { pattern: /software\s+engineer/i, role: 'Software Engineer' },
+    { pattern: /full\s*stack\s+developer/i, role: 'Full Stack Developer' },
+    { pattern: /front[\s-]?end\s+developer/i, role: 'Frontend Developer' },
+    { pattern: /back[\s-]?end\s+developer/i, role: 'Backend Developer' },
+    { pattern: /python\s+developer/i, role: 'Python Developer' },
+    { pattern: /javascript\s+developer/i, role: 'JavaScript Developer' },
+    { pattern: /engineering\s+manager/i, role: 'Engineering Manager' },
+    { pattern: /product\s+manager/i, role: 'Product Manager' },
+    { pattern: /ux\s+designer/i, role: 'UX Designer' },
+    { pattern: /ui\/ux\s+designer/i, role: 'UI/UX Designer' },
+    { pattern: /data\s+scientist/i, role: 'Data Scientist' },
+    { pattern: /data\s+analyst/i, role: 'Data Analyst' },
+    { pattern: /vp\s+(of\s+)?engineering/i, role: 'VP Engineering' },
+    { pattern: /dev\s*ops/i, role: 'DevOps Engineer' },
+  ];
+
+  for (const { pattern, role } of rolePatterns) {
+    if (pattern.test(text)) {
+      return role;
+    }
+  }
+
+  // Generic fallback
+  return 'Professional';
+}

--- a/services/vectorOperations.ts
+++ b/services/vectorOperations.ts
@@ -1,0 +1,196 @@
+export interface SkillVector {
+  // Technical skills
+  programming: number;
+  dataAnalysis: number;
+  cloudComputing: number;
+  machineLearning: number;
+  webDevelopment: number;
+  mobileDevelopment: number;
+  devOps: number;
+  databases: number;
+  
+  // Soft skills
+  leadership: number;
+  communication: number;
+  projectManagement: number;
+  teamwork: number;
+  problemSolving: number;
+  creativity: number;
+  sales: number;
+  marketing: number;
+  writing: number;
+  teaching: number;
+  design: number;
+  research: number;
+  
+  // Domain knowledge
+  finance: number;
+  healthcare: number;
+  retail: number;
+  manufacturing: number;
+  education: number;
+  government: number;
+  nonprofit: number;
+  startup: number;
+  
+  // Allow additional properties
+  [key: string]: number;
+}
+
+/**
+ * Create an empty skill vector with all dimensions set to 0
+ */
+export function createEmptyVector(): SkillVector {
+  return {
+    // Technical skills
+    programming: 0,
+    dataAnalysis: 0,
+    cloudComputing: 0,
+    machineLearning: 0,
+    webDevelopment: 0,
+    mobileDevelopment: 0,
+    devOps: 0,
+    databases: 0,
+    
+    // Soft skills
+    leadership: 0,
+    communication: 0,
+    projectManagement: 0,
+    teamwork: 0,
+    problemSolving: 0,
+    creativity: 0,
+    sales: 0,
+    marketing: 0,
+    writing: 0,
+    teaching: 0,
+    design: 0,
+    research: 0,
+    
+    // Domain knowledge
+    finance: 0,
+    healthcare: 0,
+    retail: 0,
+    manufacturing: 0,
+    education: 0,
+    government: 0,
+    nonprofit: 0,
+    startup: 0,
+  };
+}
+
+/**
+ * Normalize a vector to unit length (magnitude = 1)
+ */
+export function normalizeVector(vector: SkillVector): SkillVector {
+  const magnitude = Math.sqrt(
+    Object.values(vector).reduce((sum, val) => sum + val * val, 0)
+  );
+  
+  if (magnitude === 0) {
+    return { ...vector };
+  }
+  
+  const normalized = createEmptyVector();
+  Object.keys(vector).forEach(key => {
+    normalized[key] = vector[key] / magnitude;
+  });
+  
+  return normalized;
+}
+
+/**
+ * Calculate cosine similarity between two skill vectors
+ * Returns a value between -1 and 1, where:
+ * 1 = identical vectors
+ * 0 = orthogonal vectors
+ * -1 = opposite vectors
+ */
+export function cosineSimilarity(a: SkillVector, b: SkillVector): number {
+  const keys = Object.keys(a).filter(
+    key => (a[key] || 0) !== 0 && (b[key] || 0) !== 0
+  );
+
+  if (keys.length === 0) {
+    return 0;
+  }
+
+  let dotProduct = 0;
+  let magnitudeA = 0;
+  let magnitudeB = 0;
+
+  keys.forEach(key => {
+    const valA = a[key];
+    const valB = b[key];
+
+    dotProduct += valA * valB;
+    magnitudeA += valA * valA;
+    magnitudeB += valB * valB;
+  });
+
+  const magnitude = Math.sqrt(magnitudeA) * Math.sqrt(magnitudeB);
+
+  return magnitude === 0 ? 0 : dotProduct / magnitude;
+}
+
+/**
+ * Calculate Euclidean distance between two vectors
+ */
+export function vectorDistance(a: SkillVector, b: SkillVector): number {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  
+  let sumOfSquares = 0;
+  keys.forEach(key => {
+    const diff = (a[key] || 0) - (b[key] || 0);
+    sumOfSquares += diff * diff;
+  });
+  
+  return Math.sqrt(sumOfSquares);
+}
+
+/**
+ * Add two vectors together
+ */
+export function addVectors(a: SkillVector, b: SkillVector): SkillVector {
+  const result = createEmptyVector();
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  
+  keys.forEach(key => {
+    result[key] = (a[key] || 0) + (b[key] || 0);
+  });
+  
+  return result;
+}
+
+/**
+ * Scale a vector by a constant factor
+ */
+export function scaleVector(vector: SkillVector, scale: number): SkillVector {
+  const result = createEmptyVector();
+  
+  Object.keys(vector).forEach(key => {
+    result[key] = vector[key] * scale;
+  });
+  
+  return result;
+}
+
+/**
+ * Calculate the weighted average of multiple vectors
+ */
+export function averageVectors(vectors: SkillVector[], weights?: number[]): SkillVector {
+  if (vectors.length === 0) {
+    return createEmptyVector();
+  }
+  
+  const effectiveWeights = weights || vectors.map(() => 1 / vectors.length);
+  const result = createEmptyVector();
+  
+  vectors.forEach((vector, index) => {
+    const weight = effectiveWeights[index];
+    Object.keys(vector).forEach(key => {
+      result[key] = (result[key] || 0) + vector[key] * weight;
+    });
+  });
+  
+  return result;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,1 @@
+export type { Job } from '../app/types/Job';


### PR DESCRIPTION
## Summary
- escape regex keywords in `textToVector` to prevent invalid regex errors

## Testing
- `npx jest __tests__/services/vectorOperations.test.ts __tests__/services/skillExtraction.test.ts __tests__/services/careerMatchingService.test.ts --runInBand --silent` *(fails: 17 failed, 33 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684500052ef8832dbace503b4a4e08a2