### PR TITLE
Fix JobCardStack import

### DIFF
--- a/__tests__/screens/HomeScreen.test.tsx
+++ b/__tests__/screens/HomeScreen.test.tsx
@@ -15,7 +15,7 @@ jest.mock('../../app/components/JobCardStack', () => {
   const Text = require('react-native').Text;
   return {
     __esModule: true,
-    default: ({ jobs }: any) => (
+    JobCardStack: ({ jobs }: any) => (
       <View testID="job-card-stack">
         <Text>{jobs[0]?.title}</Text>
       </View>

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity, ActivityIndicator, ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import JobCardStack from '../components/JobCardStack';
+import { JobCardStack } from '../components/JobCardStack';
 import TemperatureSlider from '@/components/TemperatureSlider';
 import { Job } from '@/types';
 import { jobService } from '../services/jobService';

--- a/app/screens/__tests__/HomeScreen.test.tsx
+++ b/app/screens/__tests__/HomeScreen.test.tsx
@@ -15,7 +15,7 @@ jest.mock('../../services/applicationService', () => ({
 let jobCardStackProps: any;
 jest.mock('../../components/JobCardStack', () => ({
   __esModule: true,
-  default: (props: any) => {
+  JobCardStack: (props: any) => {
     jobCardStackProps = props;
     const View = require('react-native').View;
     const Text = require('react-native').Text;


### PR DESCRIPTION
## Summary
- use named export for JobCardStack in `HomeScreen`
- update HomeScreen tests to mock named export

## Testing
- `npx jest --runInBand --silent | tail -n 20` *(fails: CareerMatchingService and Skill Extraction tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845162b0c0c832db3cbc22d6352ebf9